### PR TITLE
Fix typo custoday -> custody

### DIFF
--- a/contracts/ERC1155Safe.sol
+++ b/contracts/ERC1155Safe.sol
@@ -14,7 +14,7 @@ import "@openzeppelin/contracts/token/ERC1155/presets/ERC1155PresetMinterPauser.
 contract ERC1155Safe {
 
     /**
-        @notice Used to gain custoday of deposited token with batching.
+        @notice Used to gain custody of deposited token with batching.
         @param tokenAddress Address of ERC1155 to transfer.
         @param owner Address of current token owner.
         @param recipient Address to transfer token to.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes the typo: `custoday` -> `custody`.
## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->


## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
