### PR TITLE
fix: minting xc20 tokens when executing proposal

### DIFF
--- a/contracts/XC20Safe.sol
+++ b/contracts/XC20Safe.sol
@@ -32,7 +32,7 @@ contract XC20Safe is ERC20Safe {
      */
     function mintERC20(address tokenAddress, address recipient, uint256 amount) internal override {
         IERC20Plus xc20 = IERC20Plus(tokenAddress);
-        xc20.mint(msg.sender, amount);
+        xc20.mint(address(this), amount);
         xc20.transfer(recipient, amount);
     }
 }

--- a/contracts/XC20Safe.sol
+++ b/contracts/XC20Safe.sol
@@ -11,7 +11,7 @@ import "./interfaces/IERC20Plus.sol";
     @notice This contract is intended to be used with XC20Handler contract.
  */
 contract XC20Safe is ERC20Safe {
-        /**
+    /**
         @notice Used to burn XC20s.
         @param tokenAddress Address of XC20 to burn.
         @param owner Current owner of tokens.
@@ -20,5 +20,19 @@ contract XC20Safe is ERC20Safe {
     function burnERC20(address tokenAddress, address owner, uint256 amount) internal override {
         IERC20Plus xc20 = IERC20Plus(tokenAddress);
         xc20.burn(owner, amount);
+    }
+
+    /**
+        @notice Used to mint XC20s.
+        @notice Token issuer can only mint tokens to himself (XC20Handler), overrides
+        minting tokens from ERC20Safe so it mints tokens to handler and then transferes to recipient.
+        @param tokenAddress Address of XC20 to mint.
+        @param recipient Address to mint tokens to.
+        @param amount Amount of tokens to mint.
+     */
+    function mintERC20(address tokenAddress, address recipient, uint256 amount) internal override {
+        IERC20Plus xc20 = IERC20Plus(tokenAddress);
+        xc20.mint(msg.sender, amount);
+        xc20.transfer(recipient, amount);
     }
 }


### PR DESCRIPTION
As @mpetrun5 reported when using Precompile ERC20 contract on Astar, when `executeProposal` is triggered and handler (token issuer) tries to mint tokens to recipient it fails. On Astar token issuer can only mint tokens to himself.

## Description
Fixes minting tokens to recipient on `executeProposal`:
- first mint tokens to XC20Handler
- then transfer tokens to the recipient

## Related Issue Or Context
Closes: #116 

## How Has This Been Tested? Testing details.
Unit and e2e tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
