### PR TITLE
fix: XC20 `mint/burn` tests

### DIFF
--- a/contracts/interfaces/IERC20Plus.sol
+++ b/contracts/interfaces/IERC20Plus.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 // This is based on the example from https://github.com/AstarNetwork/astar-frame/blob/674356e7b611e561aaf9bf581452cab965cf8e87/examples/assets-erc20/XcBurrito.sol#L12
 
 interface IERC20Plus is IERC20 {
-    function mint(address beneficiary, uint256 amount) external returns (bool);
-    function burn(address who, uint256 amount) external returns (bool);
+    function mint(address beneficiary, uint256 amount) external;
+    function burn(address who, uint256 amount) external;
     function decimals() external view returns (uint8);
 }

--- a/test/contractBridge/depositXC20.js
+++ b/test/contractBridge/depositXC20.js
@@ -62,7 +62,7 @@ contract("Bridge - [deposit - XRC20]", async (accounts) => {
     ]);
     await OriginXC20TestInstance.approve(
       OriginXC20HandlerInstance.address,
-      depositAmount * 2,
+      depositAmount,
       {from: depositorAddress}
     );
 
@@ -136,6 +136,13 @@ contract("Bridge - [deposit - XRC20]", async (accounts) => {
     });
 
     it("Deposit event is fired with expected value", async () => {
+      // set allowance to 2 * depositAmount since 2 deposits are made in this test
+      await OriginXC20TestInstance.approve(
+        OriginXC20HandlerInstance.address,
+        depositAmount * 2,
+        {from: depositorAddress}
+      );
+
       let depositTx = await BridgeInstance.deposit(
         destinationDomainID,
         resourceID,
@@ -193,7 +200,7 @@ contract("Bridge - [deposit - XRC20]", async (accounts) => {
   });
 
   describe("mint/burn strategy", async () => {
-    before(async () => {
+    beforeEach(async () => {
       await BridgeInstance.adminSetBurnable(
         OriginXC20HandlerInstance.address,
         OriginXC20TestInstance.address
@@ -252,10 +259,11 @@ contract("Bridge - [deposit - XRC20]", async (accounts) => {
         originChainInitialTokenAmount - depositAmount
       );
 
-      const originChainHandlerBalance = await OriginXC20TestInstance.balanceOf(
+      const originChainHandlerAllowance = await OriginXC20TestInstance.allowance(
+        depositorAddress,
         OriginXC20HandlerInstance.address
       );
-      assert.strictEqual(originChainHandlerBalance.toNumber(), depositAmount);
+      assert.strictEqual(originChainHandlerAllowance.toNumber(), depositAmount);
     });
 
     it("Deposit event is fired with expected value", async () => {

--- a/test/contractBridge/executeProposalXC20.js
+++ b/test/contractBridge/executeProposalXC20.js
@@ -70,13 +70,15 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
         XC20TestInstance.address,
         emptySetResourceData
       ),
-      XC20TestInstance.mint(depositorAddress, initialTokenAmount),
-      // XC20TestInstance.mint(XC20HandlerInstance.address, initialTokenAmount),
+      XC20TestInstance.mint(
+        depositorAddress,
+        initialTokenAmount
+      ),
     ]);
-    await XC20TestInstance.approve(
-      XC20TestInstance.address,
-      initialTokenAmount,
-      {from: depositorAddress}
+
+    await BridgeInstance.adminSetBurnable(
+      XC20HandlerInstance.address,
+      XC20TestInstance.address
     );
 
     data = Helpers.createERCDepositData(depositAmount, 20, recipientAddress);
@@ -275,6 +277,13 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
   });
 
   describe("mint/burn strategy", async () => {
+    beforeEach(async () => {
+      await BridgeInstance.adminSetBurnable(
+        XC20HandlerInstance.address,
+        XC20TestInstance.address
+      );
+    });
+
     it("isProposalExecuted returns false if depositNonce is not used", async () => {
       const destinationDomainID = await BridgeInstance._domainID();
 


### PR DESCRIPTION
## Description
* While testing [XC20 mint fix](https://github.com/sygmaprotocol/sygma-solidity/issues/116) I found `mint/burn` strategy for XC20 wasn't being tested properly (burnable was set only for first test, not all of them in `mint/burn` test suite).

* Also `mint/burn` definition in `IERC20Plus` shouldn't define return value.

## Related Issue Or Context

## How Has This Been Tested? Testing details.
- unit tests, e2e tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
