### PR TITLE
chore: improvements for ERC20 decimals values

### DIFF
--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.11;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Wrapper.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
 import "./handlers/ERCHandlerHelpers.sol";
 import "./interfaces/IERC20Plus.sol";
 
@@ -156,5 +157,17 @@ contract XC20Test is ERC20 {
 
     function burn(address from, uint256 amount) public {
         _burn(from, amount);
+    }
+}
+
+contract ERC20PresetMinterPauser_Decimals is ERC20PresetMinterPauser {
+
+    uint8 private customDecimals;
+    constructor(string memory name, string memory symbol, uint8 decimals) public ERC20PresetMinterPauser(name, symbol){
+        customDecimals = decimals;
+    }
+
+    function decimals() public view virtual override(ERC20) returns (uint8) {
+        return customDecimals;
     }
 }

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -160,7 +160,7 @@ contract XC20Test is ERC20 {
     }
 }
 
-contract ERC20PresetMinterPauser_Decimals is ERC20PresetMinterPauser {
+contract ERC20PresetMinterPauserDecimals is ERC20PresetMinterPauser {
 
     uint8 private customDecimals;
     constructor(string memory name, string memory symbol, uint8 decimals) public ERC20PresetMinterPauser(name, symbol){

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -162,7 +162,7 @@ contract XC20Test is ERC20 {
 
 contract ERC20PresetMinterPauserDecimals is ERC20PresetMinterPauser {
 
-    uint8 private customDecimals;
+    uint8 private immutable customDecimals;
     constructor(string memory name, string memory symbol, uint8 decimals) public ERC20PresetMinterPauser(name, symbol){
         customDecimals = decimals;
     }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -25,9 +25,7 @@ const DynamicFeeHandlerContract = artifacts.require("DynamicERC20FeeHandlerEVM")
 module.exports = async function (deployer, network) {
   const networksConfig = Utils.getNetworksConfig();
   // fetch deployer address
-  const deployerAddress = await deployer["networks"][deployer["network"]][
-    "from"
-  ];
+  const deployerAddress = await Utils.getDeployerAddress(deployer);
   // assign addresses for access segregation
   const functionAccessAddresses = Array(13).fill(deployerAddress);
 
@@ -128,6 +126,7 @@ module.exports = async function (deployer, network) {
     );
     console.log("ERC20 address:", "\t", erc20.address);
     console.log("ResourceID:", "\t", erc20.resourceID);
+    console.log("Decimal places:", "\t", erc20.decimals);
     console.log(
       "-------------------------------------------------------------------------------"
     );

--- a/migrations/5_renounceAdmin.js
+++ b/migrations/5_renounceAdmin.js
@@ -52,7 +52,7 @@ module.exports = async function (deployer, network) {
     );
     await feeRouterInstance.renounceRole(
       "0x00",
-      await deployer["networks"][deployer["network"]]["from"]
+      await Utils.getDeployerAddress(deployer)
     );
   }
 

--- a/migrations/local.json
+++ b/migrations/local.json
@@ -30,14 +30,48 @@
         "symbol": "ERC20LRTST",
         "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000300",
         "feeType": "basic",
-        "strategy": "lr"
+        "strategy": "lr",
+        "decimals": "18"
       },
       {
         "name": "ERC20Test",
         "symbol": "ERC20TST",
         "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "feeType": "oracle",
-        "strategy": "mb"
+        "strategy": "mb",
+        "decimals": "18"
+      },
+      {
+        "name": "ERC20LRTest_14Dec",
+        "symbol": "ERC20LRTST_14D",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000600",
+        "feeType": "basic",
+        "strategy": "lr",
+        "decimals": 14
+      },
+      {
+        "name": "ERC20Test_14Dec",
+        "symbol": "ERC20TST_14D",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000700",
+        "feeType": "oracle",
+        "strategy": "mb",
+        "decimals": 14
+      },
+      {
+        "name": "ERC20LRTest_20Dec",
+        "symbol": "ERC20LRTST_20D",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000800",
+        "feeType": "basic",
+        "strategy": "lr",
+        "decimals": 20
+      },
+      {
+        "name": "ERC20Test_20Dec",
+        "symbol": "ERC20TST_20D",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000900",
+        "feeType": "oracle",
+        "strategy": "mb",
+        "decimals": 20
       }
     ],
     "permissionedGeneric": [
@@ -85,14 +119,48 @@
         "symbol": "ERC20LRTST",
         "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000300",
         "feeType": "basic",
-        "strategy": "lr"
+        "strategy": "lr",
+        "decimals": "18"
       },
       {
         "name": "ERC20Test",
         "symbol": "ERC20TST",
         "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "feeType": "oracle",
-        "strategy": "mb"
+        "strategy": "mb",
+        "decimals": "18"
+      },
+      {
+        "name": "ERC20LRTest_14Dec",
+        "symbol": "ERC20LRTST_14D",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000600",
+        "feeType": "basic",
+        "strategy": "lr",
+        "decimals": 14
+      },
+      {
+        "name": "ERC20Test_14Dec",
+        "symbol": "ERC20TST_14D",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000700",
+        "feeType": "oracle",
+        "strategy": "mb",
+        "decimals": 14
+      },
+      {
+        "name": "ERC20LRTest_20Dec",
+        "symbol": "ERC20LRTST_20D",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000800",
+        "feeType": "basic",
+        "strategy": "lr",
+        "decimals": 20
+      },
+      {
+        "name": "ERC20Test_20Dec",
+        "symbol": "ERC20TST_20D",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000900",
+        "feeType": "oracle",
+        "strategy": "mb",
+        "decimals": 20
       }
     ],
     "permissionedGeneric": [

--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -5,7 +5,7 @@ const Ethers = require("ethers");
 const Helpers = require("../test/helpers");
 
 const TestStoreContract = artifacts.require("TestStore");
-const ERC20PresetMinterPauser = artifacts.require("ERC20PresetMinterPauser_Decimals");
+const ERC20PresetMinterPauser = artifacts.require("ERC20PresetMinterPauserDecimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 const ERC721MinterBurnerPauserContract = artifacts.require(
   "ERC721MinterBurnerPauser"

--- a/test/e2e/erc20/decimals/bothChainsNot18Decimals.js
+++ b/test/e2e/erc20/decimals/bothChainsNot18Decimals.js
@@ -3,7 +3,7 @@ const TruffleAssert = require("truffle-assertions");
 
 const Helpers = require("../../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("E2E ERC20 - Two EVM Chains both with decimal places != 18", async accounts => {
@@ -47,8 +47,12 @@ contract("E2E ERC20 - Two EVM Chains both with decimal places != 18", async acco
         await Promise.all([
             OriginBridgeInstance = await Helpers.deployBridge(originDomainID, adminAddress),
             DestinationBridgeInstance = await Helpers.deployBridge(destinationDomainID, adminAddress),
-            ERC20MintableContract.new("token", "TOK").then(instance => OriginERC20MintableInstance = instance),
-            ERC20MintableContract.new("token", "TOK").then(instance => DestinationERC20MintableInstance = instance)
+            ERC20MintableContract.new("token", "TOK", originDecimalPlaces).then(
+              instance => OriginERC20MintableInstance = instance
+            ),
+            ERC20MintableContract.new("token", "TOK", destinationDecimalPlaces).then(
+              instance => DestinationERC20MintableInstance = instance
+            )
         ]);
 
         originResourceID = Helpers.createResourceID(OriginERC20MintableInstance.address, originDomainID);
@@ -110,6 +114,28 @@ contract("E2E ERC20 - Two EVM Chains both with decimal places != 18", async acco
         // set MPC address to unpause the Bridge
         await OriginBridgeInstance.endKeygen(Helpers.mpcAddress);
         await DestinationBridgeInstance.endKeygen(Helpers.mpcAddress);
+    });
+
+    it("[sanity] check token contract decimals match set decimals on handlers", async () => {
+      const originTokenContractDecimals = (await OriginERC20MintableInstance.decimals()).toNumber();
+      const originDecimalsSetOnHandler =  (
+        await OriginERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+          OriginERC20MintableInstance.address
+      )).decimals
+
+      const destinationTokenContractDecimals = (await DestinationERC20MintableInstance.decimals()).toNumber();
+      const destinationDecimalsSetOnHandler =  (await DestinationERC20HandlerInstance
+        ._tokenContractAddressToTokenProperties.call(DestinationERC20MintableInstance.address
+      )).decimals
+
+      assert.strictEqual(
+        originTokenContractDecimals.toString(),
+        originDecimalsSetOnHandler["externalDecimals"]
+      );
+      assert.strictEqual(
+        destinationTokenContractDecimals.toString(),
+        destinationDecimalsSetOnHandler["externalDecimals"]
+      );
     });
 
     it(`E2E: depositAmount of Origin ERC20 owned by depositAddress to Destination ERC20

--- a/test/e2e/erc20/decimals/bothChainsNot18Decimals.js
+++ b/test/e2e/erc20/decimals/bothChainsNot18Decimals.js
@@ -3,7 +3,7 @@ const TruffleAssert = require("truffle-assertions");
 
 const Helpers = require("../../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauserDecimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("E2E ERC20 - Two EVM Chains both with decimal places != 18", async accounts => {

--- a/test/e2e/erc20/decimals/oneChainNot18Decimals.js
+++ b/test/e2e/erc20/decimals/oneChainNot18Decimals.js
@@ -3,7 +3,7 @@ const TruffleAssert = require("truffle-assertions");
 
 const Helpers = require("../../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauserDecimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with != 18", async accounts => {

--- a/test/e2e/erc20/decimals/oneChainNot18Decimals.js
+++ b/test/e2e/erc20/decimals/oneChainNot18Decimals.js
@@ -3,7 +3,7 @@ const TruffleAssert = require("truffle-assertions");
 
 const Helpers = require("../../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with != 18", async accounts => {
@@ -52,8 +52,12 @@ contract("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with 
         await Promise.all([
             OriginBridgeInstance = await Helpers.deployBridge(originDomainID, adminAddress),
             DestinationBridgeInstance = await Helpers.deployBridge(destinationDomainID, adminAddress),
-            ERC20MintableContract.new("token", "TOK").then(instance => OriginERC20MintableInstance = instance),
-            ERC20MintableContract.new("token", "TOK").then(instance => DestinationERC20MintableInstance = instance)
+            ERC20MintableContract.new("token", "TOK", originDecimalPlaces).then(
+              instance => OriginERC20MintableInstance = instance
+            ),
+            ERC20MintableContract.new("token", "TOK", destinationDecimalPlaces).then(
+              instance => DestinationERC20MintableInstance = instance
+            )
         ]);
 
         originResourceID = Helpers.createResourceID(OriginERC20MintableInstance.address, originDomainID);
@@ -123,6 +127,28 @@ contract("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with 
         // set MPC address to unpause the Bridge
         await OriginBridgeInstance.endKeygen(Helpers.mpcAddress);
         await DestinationBridgeInstance.endKeygen(Helpers.mpcAddress);
+    });
+
+    it("[sanity] check token contract decimals match set decimals on handlers", async () => {
+      const originTokenContractDecimals = (await OriginERC20MintableInstance.decimals()).toNumber();
+      const originDecimalsSetOnHandler =  (
+        await OriginERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+          OriginERC20MintableInstance.address
+      )).decimals
+
+      const destinationDecimalsSetOnHandler =  (await DestinationERC20HandlerInstance
+        ._tokenContractAddressToTokenProperties.call(DestinationERC20MintableInstance.address
+      )).decimals
+
+      assert.strictEqual(
+        originTokenContractDecimals.toString(),
+        originDecimalsSetOnHandler["externalDecimals"]
+      );
+      assert.isFalse(destinationDecimalsSetOnHandler["isSet"]);
+      assert.strictEqual(
+        "0",
+        destinationDecimalsSetOnHandler["externalDecimals"]
+      );
     });
 
     it(`E2E: depositAmount of Origin ERC20 owned by depositAddress to Destination ERC20

--- a/test/e2e/erc20/decimals/oneChainWith0Decimals.js
+++ b/test/e2e/erc20/decimals/oneChainWith0Decimals.js
@@ -3,7 +3,7 @@ const TruffleAssert = require("truffle-assertions");
 
 const Helpers = require("../../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauserDecimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with == 0", async accounts => {

--- a/test/e2e/erc20/decimals/oneChainWith0Decimals.js
+++ b/test/e2e/erc20/decimals/oneChainWith0Decimals.js
@@ -3,7 +3,7 @@ const TruffleAssert = require("truffle-assertions");
 
 const Helpers = require("../../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with == 0", async accounts => {
@@ -52,8 +52,12 @@ contract("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with 
         await Promise.all([
             OriginBridgeInstance = await Helpers.deployBridge(originDomainID, adminAddress),
             DestinationBridgeInstance = await Helpers.deployBridge(destinationDomainID, adminAddress),
-            ERC20MintableContract.new("token", "TOK").then(instance => OriginERC20MintableInstance = instance),
-            ERC20MintableContract.new("token", "TOK").then(instance => DestinationERC20MintableInstance = instance)
+            ERC20MintableContract.new("token", "TOK", originDecimalPlaces).then(
+              instance => OriginERC20MintableInstance = instance
+            ),
+            ERC20MintableContract.new("token", "TOK", destinationDecimalPlaces).then(
+              instance => DestinationERC20MintableInstance = instance
+            )
         ]);
 
         originResourceID = Helpers.createResourceID(OriginERC20MintableInstance.address, originDomainID);
@@ -123,6 +127,28 @@ contract("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with 
         // set MPC address to unpause the Bridge
         await OriginBridgeInstance.endKeygen(Helpers.mpcAddress);
         await DestinationBridgeInstance.endKeygen(Helpers.mpcAddress);
+    });
+
+    it("[sanity] check token contract decimals match set decimals on handlers", async () => {
+      const originTokenContractDecimals = (await OriginERC20MintableInstance.decimals()).toNumber();
+      const originDecimalsSetOnHandler =  (
+        await OriginERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+          OriginERC20MintableInstance.address
+      )).decimals
+
+      const destinationDecimalsSetOnHandler =  (await DestinationERC20HandlerInstance
+        ._tokenContractAddressToTokenProperties.call(DestinationERC20MintableInstance.address
+      )).decimals
+
+      assert.strictEqual(
+        originTokenContractDecimals.toString(),
+        originDecimalsSetOnHandler["externalDecimals"]
+      );
+      assert.isFalse(destinationDecimalsSetOnHandler["isSet"]);
+      assert.strictEqual(
+        "0",
+        destinationDecimalsSetOnHandler["externalDecimals"]
+      );
     });
 
     it(`E2E: depositAmount of Origin ERC20 owned by depositAddress to Destination ERC20

--- a/test/e2e/erc20/decimals/roundingLoss.js
+++ b/test/e2e/erc20/decimals/roundingLoss.js
@@ -3,7 +3,7 @@ const TruffleAssert = require("truffle-assertions");
 
 const Helpers = require("../../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauserDecimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("E2E ERC20 - Two EVM Chains both with decimal places != 18 with rounding loss", async accounts => {

--- a/test/e2e/erc20/decimals/roundingLoss.js
+++ b/test/e2e/erc20/decimals/roundingLoss.js
@@ -3,7 +3,7 @@ const TruffleAssert = require("truffle-assertions");
 
 const Helpers = require("../../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("E2E ERC20 - Two EVM Chains both with decimal places != 18 with rounding loss", async accounts => {
@@ -49,8 +49,12 @@ contract("E2E ERC20 - Two EVM Chains both with decimal places != 18 with roundin
         await Promise.all([
             OriginBridgeInstance = await Helpers.deployBridge(originDomainID, adminAddress),
             DestinationBridgeInstance = await Helpers.deployBridge(destinationDomainID, adminAddress),
-            ERC20MintableContract.new("token", "TOK").then(instance => OriginERC20MintableInstance = instance),
-            ERC20MintableContract.new("token", "TOK").then(instance => DestinationERC20MintableInstance = instance)
+            ERC20MintableContract.new("token", "TOK", originDecimalPlaces).then(
+              instance => OriginERC20MintableInstance = instance
+            ),
+            ERC20MintableContract.new("token", "TOK", destinationDecimalPlaces).then(
+              instance => DestinationERC20MintableInstance = instance
+            )
         ]);
 
         originResourceID = Helpers.createResourceID(OriginERC20MintableInstance.address, originDomainID);
@@ -112,6 +116,28 @@ contract("E2E ERC20 - Two EVM Chains both with decimal places != 18 with roundin
         // set MPC address to unpause the Bridge
         await OriginBridgeInstance.endKeygen(Helpers.mpcAddress);
         await DestinationBridgeInstance.endKeygen(Helpers.mpcAddress);
+    });
+
+    it("[sanity] check token contract decimals match set decimals on handlers", async () => {
+      const originTokenContractDecimals = (await OriginERC20MintableInstance.decimals()).toNumber();
+      const originDecimalsSetOnHandler =  (
+        await OriginERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+          OriginERC20MintableInstance.address
+      )).decimals
+
+      const destinationTokenContractDecimals = (await DestinationERC20MintableInstance.decimals()).toNumber();
+      const destinationDecimalsSetOnHandler =  (await DestinationERC20HandlerInstance
+        ._tokenContractAddressToTokenProperties.call(DestinationERC20MintableInstance.address
+      )).decimals
+
+      assert.strictEqual(
+        originTokenContractDecimals.toString(),
+        originDecimalsSetOnHandler["externalDecimals"]
+      );
+      assert.strictEqual(
+        destinationTokenContractDecimals.toString(),
+        destinationDecimalsSetOnHandler["externalDecimals"]
+      );
     });
 
     it(`E2E: depositAmount of Origin ERC20 owned by depositAddress to Destination ERC20

--- a/test/handlers/erc20/decimals.js
+++ b/test/handlers/erc20/decimals.js
@@ -6,7 +6,7 @@
 
 const Helpers = require("../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("ERC20Handler - [decimals]", async (accounts) => {
@@ -33,7 +33,7 @@ contract("ERC20Handler - [decimals]", async (accounts) => {
   beforeEach(async () => {
       await Promise.all([
           BridgeInstance = await Helpers.deployBridge(originDomainID, accounts[0]),
-          ERC20MintableContract.new("token", "TOK").then(instance => ERC20MintableInstance = instance)
+          ERC20MintableContract.new("token", "TOK", 11).then(instance => ERC20MintableInstance = instance)
       ]);
 
       resourceID = Helpers.createResourceID(ERC20MintableInstance.address, originDomainID);
@@ -70,10 +70,14 @@ contract("ERC20Handler - [decimals]", async (accounts) => {
   });
 
   it("[sanity] decimals value is not set if 'adminSetResource' is called with empty args", async () => {
-      const ERC20MintableInstanceDecimals = await ERC20HandlerInstance._decimals.call(ERC20MintableInstance.address);
+      const ERC20MintableInstanceDecimals = (await ERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+        await ERC20MintableInstance.address
+      )).decimals;
+
+      console.log("ERC20MintableInstanceDecimals",ERC20MintableInstanceDecimals["externalDecimals"])
 
       assert.strictEqual(ERC20MintableInstanceDecimals.isSet, false)
-      assert.strictEqual(ERC20MintableInstanceDecimals.externalDecimals.toNumber(), 0)
+      assert.strictEqual(ERC20MintableInstanceDecimals["externalDecimals"], "0")
   });
 
   it("[sanity] decimals value is set if args are provided to 'adminSetResource'", async () => {
@@ -85,9 +89,15 @@ contract("ERC20Handler - [decimals]", async (accounts) => {
         setDecimalPlaces
       );
 
-      const ERC20MintableInstanceDecimals = await ERC20HandlerInstance._decimals.call(ERC20MintableInstance.address);
+      const ERC20MintableInstanceDecimals = (await ERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+        ERC20MintableInstance.address
+      )).decimals;
 
-      assert.strictEqual(ERC20MintableInstanceDecimals.isSet, true)
-      assert.strictEqual(ERC20MintableInstanceDecimals.externalDecimals.toNumber(), 11)
+      assert.strictEqual(ERC20MintableInstanceDecimals.isSet, true);
+      assert.strictEqual(ERC20MintableInstanceDecimals["externalDecimals"], "11");
+      assert.strictEqual(
+        ERC20MintableInstanceDecimals["externalDecimals"],
+        (await ERC20MintableInstance.decimals()).toString()
+      );
   });
 });

--- a/test/handlers/erc20/decimals.js
+++ b/test/handlers/erc20/decimals.js
@@ -6,7 +6,7 @@
 
 const Helpers = require("../../helpers");
 
-const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser_Decimals");
+const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauserDecimals");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 
 contract("ERC20Handler - [decimals]", async (accounts) => {


### PR DESCRIPTION
## Description
* Remove `decimals` mapping and store those values in `_tokenContractAddressToTokenProperties` since it has the same key.
* Introduce ERC20 token with customizable decimals value for our testing envs, to have a more real life examples.

## Related Issue Or Context
Closes: #138 

## How Has This Been Tested? Testing details.
Unit tests and e2e tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
