### PR TITLE
fix: deploy and register one token handler per network

### DIFF
--- a/migrations/6_redeploy_token_handlers.js
+++ b/migrations/6_redeploy_token_handlers.js
@@ -9,6 +9,10 @@ const BridgeContract = artifacts.require("Bridge");
 const ERC20HandlerContract = artifacts.require("ERC20Handler");
 const XC20HandlerContract = artifacts.require("XC20Handler");
 
+const TOKEN_TYPE = {
+  ERC20: "erc20",
+  XC20: "xc20"
+}
 
 module.exports = async function (deployer, network) {
   // check if "redeploy-token-handlers" is provided -> redeploys
@@ -31,27 +35,26 @@ module.exports = async function (deployer, network) {
       console.error(e)
     }
 
-    // deploy and migrate erc20 handler to new handler
-    for (const erc20 of currentNetworkConfig.erc20) {
-      await Utils.migrateToNewTokenHandler(
-        deployer,
-        erc20,
-        bridgeInstance,
-        erc20HandlerInstance,
-      );
-    }
+    // redeploy and register ERC20 handler
+    await Utils.redeployHandler(
+      deployer,
+      currentNetworkConfig,
+      bridgeInstance,
+      ERC20HandlerContract,
+      erc20HandlerInstance,
+      TOKEN_TYPE.ERC20
+    );
 
-    // deploy and migrate erc20 handler to new handler if
-    // xc20 handler is deployed on current network
-    if (xc20HandlerInstance) {
-      for (const xc20 of currentNetworkConfig.xc20) {
-        await Utils.migrateToNewTokenHandler(
-          deployer,
-          xc20,
-          bridgeInstance,
-          xc20HandlerInstance,
-        );
-      }
+    // redeploy XC20 handler and register (if deployed to current network)
+    if(currentNetworkConfig.xc20 && xc20HandlerInstance){
+      await Utils.redeployHandler(
+        deployer,
+        currentNetworkConfig,
+        bridgeInstance,
+        XC20HandlerContract,
+        xc20HandlerInstance,
+        TOKEN_TYPE.XC20
+      );
     }
   }
 }


### PR DESCRIPTION
## Description
Currently when redeploying and registering new handlers migration is executed it deploys and registers a new handler for each token.
Expected behaviour should be to deploy one token handler per network and register all belonging tokens to that handler.

## Related Issue Or Context
Closes: #147

## How Has This Been Tested? Testing details.
Manual tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
