### PR TITLE
fix: set new handler as minter

### DIFF
--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -216,8 +216,18 @@ async function migrateToNewTokenHandler(
     tokenConfig.decimals != "18" ? tokenConfig.decimals : emptySetResourceData
   );
 
-  if(tokenConfig.strategy === "mb"){
-    await bridgeInstance.adminSetBurnable(newHandlerInstance.address, tokenContractAddress);
+    if(tokenConfig.strategy === "mb"){
+      const erc20Instance = await ERC20PresetMinterPauser.at(tokenContractAddress);
+
+    await erc20Instance.grantRole(
+      await erc20Instance.MINTER_ROLE(),
+      newHandlerInstance.address
+    );
+
+    await bridgeInstance.adminSetBurnable(
+      newHandlerInstance.address,
+      tokenContractAddress
+    );
   }
 
   console.log("Associated resourceID:", "\t", tokenConfig.resourceID);


### PR DESCRIPTION
## Description
When migrating ERC20 handler set new handler as minter for tokens that use mint/burn strategy.

## Related Issue Or Context
## How Has This Been Tested? Testing details.
manual tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
