### PR TITLE
chore: PermissionlessGenericHandler: unpack depositor address with custom length

### DIFF
--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -171,3 +171,35 @@ contract ERC20PresetMinterPauserDecimals is ERC20PresetMinterPauser {
         return customDecimals;
     }
 }
+
+contract TestDeposit {
+    event TestExecute(address depositor, uint256 num, address addr, bytes message);
+
+    /**
+        This helper can be used to prepare execution data for PermissionlessGenericHandler.
+        The execution data will be packed together with depositorAddress before execution.
+        If the target function parameters include reference types then the offsets should be kept consistent.
+        This function packs the parameters together with a fake address and removes the address.
+        After repacking in the handler together with depositorAddress, the offsets will be correct.
+    */
+    function prepareDepositData(bytes calldata executionData) view external returns (bytes memory) {
+        bytes memory encoded = abi.encode(address(0), executionData);
+        return this.slice32(encoded);
+    }
+
+    function slice32(bytes calldata input) pure public returns (bytes memory) {
+        return input[32:];
+    }
+
+    function executePacked(address depositor, bytes calldata data) external {
+        uint256 num;
+        address[] memory arr;
+        bytes memory message;
+        (num, arr, message) = abi.decode(data, (uint256, address[], bytes));
+        emit TestExecute(depositor, num, arr[1], message);
+    }
+
+    function executeUnpacked(address depositor, uint256 num, address[] memory addresses, bytes memory message) external {
+        emit TestExecute(depositor, num, addresses[1], message);
+    }
+}

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -184,19 +184,19 @@ contract TestDeposit {
     */
     function prepareDepositData(bytes calldata executionData) view external returns (bytes memory) {
         bytes memory encoded = abi.encode(address(0), executionData);
-        return this.slice32(encoded);
+        return this.slice(encoded, 32);
     }
 
-    function slice32(bytes calldata input) pure public returns (bytes memory) {
-        return input[32:];
+    function slice(bytes calldata input, uint256 position) pure public returns (bytes memory) {
+        return input[position:];
     }
 
     function executePacked(address depositor, bytes calldata data) external {
         uint256 num;
-        address[] memory arr;
+        address[] memory addresses;
         bytes memory message;
-        (num, arr, message) = abi.decode(data, (uint256, address[], bytes));
-        emit TestExecute(depositor, num, arr[1], message);
+        (num, addresses, message) = abi.decode(data, (uint256, address[], bytes));
+        emit TestExecute(depositor, num, addresses[1], message);
     }
 
     function executeUnpacked(address depositor, uint256 num, address[] memory addresses, bytes memory message) external {

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -176,11 +176,15 @@ contract TestDeposit {
     event TestExecute(address depositor, uint256 num, address addr, bytes message);
 
     /**
-        This helper can be used to prepare execution data for PermissionlessGenericHandler.
-        The execution data will be packed together with depositorAddress before execution.
-        If the target function parameters include reference types then the offsets should be kept consistent.
-        This function packs the parameters together with a fake address and removes the address.
+        This helper can be used to prepare execution data for Bridge.deposit() on the source chain
+        if PermissionlessGenericHandler is used 
+        and if the target function accepts (address depositor, bytes executionData).
+        The execution data (packed as bytes) will be packed together with depositorAddress 
+        in PermissionlessGenericHandler before execution on the target chain.
+        This function packs the bytes parameter together with a fake address and removes the address.
         After repacking in the handler together with depositorAddress, the offsets will be correct.
+        Usage: pack all parameters as bytes, then use this function, then pack the result of this function
+        together with maxFee, executeFuncSignature etc and pass it to Bridge.deposit().
     */
     function prepareDepositData(bytes calldata executionData) view external returns (bytes memory) {
         bytes memory encoded = abi.encode(address(0), executionData);

--- a/contracts/handlers/PermissionlessGenericHandler.sol
+++ b/contracts/handlers/PermissionlessGenericHandler.sol
@@ -70,6 +70,8 @@ contract PermissionlessGenericHandler is IHandler {
             function slice(bytes calldata input, uint256 position) pure public returns (bytes memory) {
                 return input[position:];
             }
+          After this, the target contract will get the following:
+          executeFuncSignature(address executionDataDepositor, bytes executionData)
 
           Another example: if the target function accepts (address depositor, uint[], address)
           then a function like the following one can be used:
@@ -80,7 +82,7 @@ contract PermissionlessGenericHandler is IHandler {
             }
 
           After this, the target contract will get the following:
-          executeFuncSignature(executionDataDepositor, executionData)
+          executeFuncSignature(address executionDataDepositor, uint[] uintArray, address addr)
      */
     function deposit(bytes32 resourceID, address depositor, bytes calldata data) external view returns (bytes memory) {
         require(data.length >= 76, "Incorrect data length"); // 32 + 2 + 1 + 1 + 20 + 20
@@ -126,6 +128,9 @@ contract PermissionlessGenericHandler is IHandler {
                 return input[position:];
             }
 
+          After this, the target contract will get the following:
+          executeFuncSignature(address executionDataDepositor, bytes executionData)
+
           Another example: if the target function accepts (address depositor, uint[], address)
           then a function like the following one can be used:
             
@@ -135,7 +140,7 @@ contract PermissionlessGenericHandler is IHandler {
             }
 
           After this, the target contract will get the following:
-          executeFuncSignature(executionDataDepositor, executionData)
+          executeFuncSignature(address executionDataDepositor, uint[] uintArray, address addr)
      */
     function executeProposal(bytes32 resourceID, bytes calldata data) external onlyBridge {
         uint16         lenExecuteFuncSignature;

--- a/contracts/handlers/PermissionlessGenericHandler.sol
+++ b/contracts/handlers/PermissionlessGenericHandler.sol
@@ -55,6 +55,20 @@ contract PermissionlessGenericHandler is IHandler {
           len(executionDataDepositor):  uint8    bytes  35 + len(executeFuncSignature) + len(executeContractAddress)                                -  36 + len(executeFuncSignature) + len(executeContractAddress)
           executionDataDepositor:       bytes    bytes  36 + len(executeFuncSignature) + len(executeContractAddress)                                -  36 + len(executeFuncSignature) + len(executeContractAddress) + len(executionDataDepositor)
           executionData:                bytes    bytes  36 + len(executeFuncSignature) + len(executeContractAddress) + len(executionDataDepositor)  -  END
+
+          executionData is repacked together with executionDataDepositor address for using it in the target contract.
+          If executionData contains dynamic types then it is necessary to keep the offsets correct.
+          executionData should be encoded together with a 32-byte address and then passed as a parameter without that address.
+          A function like the following one can be used:
+
+            function prepareDepositData(bytes calldata executionData) view external returns (bytes memory) {
+                bytes memory encoded = abi.encode(address(0), executionData);
+                return this.slice32(encoded);
+            }
+
+            function slice32(bytes calldata input) pure public returns (bytes memory) {
+                return input[32:];
+            }
      */
     function deposit(bytes32 resourceID, address depositor, bytes calldata data) external view returns (bytes memory) {
         require(data.length >= 76, "Incorrect data length"); // 32 + 2 + 1 + 1 + 20 + 20
@@ -82,8 +96,20 @@ contract PermissionlessGenericHandler is IHandler {
           len(executeContractAddress):        uint8    bytes  34 + len(executeFuncSignature)                                -  35 + len(executeFuncSignature)
           executeContractAddress              bytes    bytes  35 + len(executeFuncSignature)                                -  35 + len(executeFuncSignature) + len(executeContractAddress)
           len(executionDataDepositor):        uint8    bytes  35 + len(executeFuncSignature) + len(executeContractAddress)  -  36 + len(executeFuncSignature) + len(executeContractAddress)
-          executionDataDepositor:       bytes    bytes  36 + len(executeFuncSignature) + len(executeContractAddress)                                -  36 + len(executeFuncSignature) + len(executeContractAddress) + len(executionDataDepositor)
-          executionData:                bytes    bytes  36 + len(executeFuncSignature) + len(executeContractAddress) + len(executionDataDepositor)  -  END
+          executionDataDepositor:             bytes    bytes  36 + len(executeFuncSignature) + len(executeContractAddress)                                -  36 + len(executeFuncSignature) + len(executeContractAddress) + len(executionDataDepositor)
+          executionData:                      bytes    bytes  36 + len(executeFuncSignature) + len(executeContractAddress) + len(executionDataDepositor)  -  END
+
+          executionData is repacked together with executionDataDepositor address for using it in the target contract.
+          If executionData contains dynamic types then it is necessary to keep the offsets correct.
+          executionData should be encoded together with a 32-byte address and then passed as a parameter without that address.
+          A function like the following one can be used:
+
+          function prepareDepositData(bytes memory executionData) {
+            return abi.encode(address(0), executiondata)[32:];
+          }
+
+          After this, the target contract will get the following:
+          executeFuncSignature(executionDataDepositor, executionData)
      */
     function executeProposal(bytes32 resourceID, bytes calldata data) external onlyBridge {
         uint16         lenExecuteFuncSignature;

--- a/contracts/handlers/PermissionlessGenericHandler.sol
+++ b/contracts/handlers/PermissionlessGenericHandler.sol
@@ -59,7 +59,8 @@ contract PermissionlessGenericHandler is IHandler {
           executionData is repacked together with executionDataDepositor address for using it in the target contract.
           If executionData contains dynamic types then it is necessary to keep the offsets correct.
           executionData should be encoded together with a 32-byte address and then passed as a parameter without that address.
-          A helper function like the following one can be used:
+          If the target function accepts (address depositor, bytes executionData) 
+          then a function like the following one can be used:
 
             function prepareDepositData(bytes calldata executionData) view external returns (bytes memory) {
                 bytes memory encoded = abi.encode(address(0), executionData);
@@ -70,7 +71,16 @@ contract PermissionlessGenericHandler is IHandler {
                 return input[position:];
             }
 
-          Or, if 
+          Another example: if the target function accepts (address depositor, uint[], address)
+          then a function like the following one can be used:
+            
+            function prepareDepositData(uint[] calldata uintArray, address addr) view external returns (bytes memory) {
+                bytes memory encoded = abi.encode(address(0), uintArray, addr);
+                return this.slice(encoded, 32);
+            }
+
+          After this, the target contract will get the following:
+          executeFuncSignature(executionDataDepositor, executionData)
      */
     function deposit(bytes32 resourceID, address depositor, bytes calldata data) external view returns (bytes memory) {
         require(data.length >= 76, "Incorrect data length"); // 32 + 2 + 1 + 1 + 20 + 20

--- a/test/handlers/generic/permissionlessDeposit.js
+++ b/test/handlers/generic/permissionlessDeposit.js
@@ -117,7 +117,7 @@ contract("PermissionlessGenericHandler - [deposit]", async (accounts) => {
   });
 
   it("deposit data should be of required length", async () => {
-    const invalidDepositData = "0x" + "02a3d".repeat(31);
+    const invalidDepositData = "0x" + "aa".repeat(75);
 
     await TruffleAssert.reverts(
       BridgeInstance.deposit(

--- a/test/handlers/generic/permissionlessDeposit.js
+++ b/test/handlers/generic/permissionlessDeposit.js
@@ -117,6 +117,7 @@ contract("PermissionlessGenericHandler - [deposit]", async (accounts) => {
   });
 
   it("deposit data should be of required length", async () => {
+    // Min length is 76 bytes
     const invalidDepositData = "0x" + "aa".repeat(75);
 
     await TruffleAssert.reverts(

--- a/test/handlers/generic/permissionlessExecuteProposal.js
+++ b/test/handlers/generic/permissionlessExecuteProposal.js
@@ -294,7 +294,9 @@ contract(
       const addresses = [BridgeInstance.address, TestStoreInstance.address];
       const message = Ethers.utils.hexlify(Ethers.utils.toUtf8Bytes("message"));
 
-      const executionData = Helpers.createPermissionlessGenericExecutionData(["uint", "address[]", "bytes"], [num, addresses, message]);
+      const executionData = Helpers.createPermissionlessGenericExecutionData(
+        ["uint", "address[]", "bytes"], [num, addresses, message]
+      );
 
       const depositFunctionSignature = Helpers.getFunctionSignature(
         TestDepositInstance,

--- a/test/handlers/generic/permissionlessExecuteProposal.js
+++ b/test/handlers/generic/permissionlessExecuteProposal.js
@@ -227,7 +227,8 @@ contract(
       const message = Ethers.utils.hexlify(Ethers.utils.toUtf8Bytes("message"));
       const executionData = Helpers.abiEncode(["uint", "address[]", "bytes"], [num, addresses, message]);
         
-
+      // If the target function accepts (address depositor, bytes executionData)
+      // then this helper can be used
       const preparedExecutionData = await TestDepositInstance.prepareDepositData(executionData);
       const depositFunctionSignature = Helpers.getFunctionSignature(
         TestDepositInstance,

--- a/test/handlers/generic/permissionlessExecuteProposal.js
+++ b/test/handlers/generic/permissionlessExecuteProposal.js
@@ -8,6 +8,7 @@ const Ethers = require("ethers");
 const Helpers = require("../../helpers");
 
 const TestStoreContract = artifacts.require("TestStore");
+const TestDepositContract = artifacts.require("TestDeposit");
 const PermissionlessGenericHandlerContract = artifacts.require(
   "PermissionlessGenericHandler"
 );
@@ -30,6 +31,7 @@ contract(
 
     let BridgeInstance;
     let TestStoreInstance;
+    let TestDepositInstance;
 
     let resourceID;
     let depositFunctionSignature;
@@ -45,6 +47,9 @@ contract(
         )),
         TestStoreContract.new().then(
           (instance) => (TestStoreInstance = instance)
+        ),
+        TestDepositContract.new().then(
+          (instance) => (TestDepositInstance = instance)
         ),
       ]);
 
@@ -214,6 +219,141 @@ contract(
       assert.isTrue(
         await TestStoreInstance._assetsStored.call(hashOfTestStore)
       );
+    });
+
+    it("call with packed depositData should be successful", async () => {
+      const num = 5;
+      const addresses = [BridgeInstance.address, TestStoreInstance.address];
+      const message = Ethers.utils.hexlify(Ethers.utils.toUtf8Bytes("message"));
+      const executionData = Helpers.abiEncode(["uint", "address[]", "bytes"], [num, addresses, message]);
+        
+
+      const preparedExecutionData = await TestDepositInstance.prepareDepositData(executionData);
+      const depositFunctionSignature = Helpers.getFunctionSignature(
+        TestDepositInstance,
+        "executePacked"
+      );
+      const depositData = Helpers.createPermissionlessGenericDepositData(
+        depositFunctionSignature,
+        TestDepositInstance.address,
+        destinationMaxFee,
+        depositorAddress,
+        preparedExecutionData
+      );
+
+      const proposal = {
+        originDomainID: originDomainID,
+        depositNonce: expectedDepositNonce,
+        data: depositData,
+        resourceID: resourceID,
+      };
+      const proposalSignedData = await Helpers.signTypedProposal(
+        BridgeInstance.address,
+        [proposal]
+      );
+      await TruffleAssert.passes(
+        BridgeInstance.deposit(
+          originDomainID,
+          resourceID,
+          depositData,
+          feeData,
+          {from: depositorAddress}
+        )
+      );
+
+      // relayer1 executes the proposal
+      const executeTx = await BridgeInstance.executeProposal(proposal, proposalSignedData, {
+        from: relayer1Address,
+      });
+
+      const internalTx = await TruffleAssert.createTransactionResult(
+        TestDepositInstance,
+        executeTx.tx
+      );
+
+      // check that ProposalExecution event is emitted
+      TruffleAssert.eventEmitted(executeTx, "ProposalExecution", (event) => {
+        return (
+          event.originDomainID.toNumber() === originDomainID &&
+          event.depositNonce.toNumber() === expectedDepositNonce
+        );
+      });
+
+      TruffleAssert.eventEmitted(internalTx, "TestExecute", (event) => {
+        return (
+          event.depositor === depositorAddress &&
+          event.num.toNumber() === num &&
+          event.addr === TestStoreInstance.address &&
+          event.message === message
+        );
+      });
+    });
+
+    it("call with unpacked depositData should be successful", async () => {
+      const num = 5;
+      const addresses = [BridgeInstance.address, TestStoreInstance.address];
+      const message = Ethers.utils.hexlify(Ethers.utils.toUtf8Bytes("message"));
+
+      const executionData = Helpers.createPermissionlessGenericExecutionData(["uint", "address[]", "bytes"], [num, addresses, message]);
+
+      const depositFunctionSignature = Helpers.getFunctionSignature(
+        TestDepositInstance,
+        "executeUnpacked"
+      );
+      const depositData = Helpers.createPermissionlessGenericDepositData(
+        depositFunctionSignature,
+        TestDepositInstance.address,
+        destinationMaxFee,
+        depositorAddress,
+        executionData
+      );
+
+      const proposal = {
+        originDomainID: originDomainID,
+        depositNonce: expectedDepositNonce,
+        data: depositData,
+        resourceID: resourceID,
+      };
+      const proposalSignedData = await Helpers.signTypedProposal(
+        BridgeInstance.address,
+        [proposal]
+      );
+      await TruffleAssert.passes(
+        BridgeInstance.deposit(
+          originDomainID,
+          resourceID,
+          depositData,
+          feeData,
+          {from: depositorAddress}
+        )
+      );
+
+      // relayer1 executes the proposal
+      const executeTx = await BridgeInstance.executeProposal(proposal, proposalSignedData, {
+        from: relayer1Address,
+      });
+
+      const internalTx = await TruffleAssert.createTransactionResult(
+        TestDepositInstance,
+        executeTx.tx
+      );
+
+      // check that ProposalExecution event is emitted
+      TruffleAssert.eventEmitted(executeTx, "ProposalExecution", (event) => {
+        return (
+          event.originDomainID.toNumber() === originDomainID &&
+          event.depositNonce.toNumber() === expectedDepositNonce
+        );
+      });
+
+      TruffleAssert.eventEmitted(internalTx, "TestExecute", (event) => {
+        return (
+          event.depositor === depositorAddress &&
+          event.num.toNumber() === num &&
+          event.addr === TestStoreInstance.address &&
+          event.message === message
+        );
+      });
     });
   }
 );

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -343,6 +343,20 @@ const createDepositProposalDataFromHandlerResponse = (
 };
 
 
+// This helper can be used to prepare execution data for PermissionlessGenericHandler
+// The execution data will be packed together with depositorAddress before execution.
+// If the target function parameters include reference types then the offsets should be kept consistent.
+// This function packs the parameters together with a fake address and removes the address.
+// After repacking in the handler together with depositorAddress, the offsets will be correct.
+const createPermissionlessGenericExecutionData = (
+  types,
+  values
+) => {
+  types.unshift("address");
+  values.unshift(Ethers.constants.AddressZero);
+  return "0x" + abiEncode(types, values).substr(66);
+};
+
 module.exports = {
   advanceBlock,
   advanceTime,
@@ -373,4 +387,5 @@ module.exports = {
   signTypedProposal,
   mockSignTypedProposalWithInvalidChainID,
   createDepositProposalDataFromHandlerResponse,
+  createPermissionlessGenericExecutionData
 };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -348,6 +348,10 @@ const createDepositProposalDataFromHandlerResponse = (
 // If the target function parameters include reference types then the offsets should be kept consistent.
 // This function packs the parameters together with a fake address and removes the address.
 // After repacking the data in the handler together with depositorAddress, the offsets will be correct.
+// Usage: use this function to prepare execution data,
+// then pack the result together with executeFunctionSignature, maxFee etc 
+// (using the createPermissionlessGenericDepositData() helper)
+// and then pass the data to Bridge.deposit().
 const createPermissionlessGenericExecutionData = (
   types,
   values

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -150,8 +150,8 @@ const createPermissionlessGenericDepositData = (
     executeFunctionSignature.substr(2) + // bytes
     toHex(executeContractAddress.substr(2).length / 2, 1).substr(2) + // uint8
     executeContractAddress.substr(2) + // bytes
-    toHex(32, 1).substr(2) + // uint8
-    toHex(depositor, 32).substr(2) + // bytes32
+    toHex(depositor.substr(2).length / 2, 1).substr(2) + // uint8
+    depositor.substr(2) + // bytes
     executionData.substr(2)
   ) // bytes
     .toLowerCase();

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -347,7 +347,7 @@ const createDepositProposalDataFromHandlerResponse = (
 // The execution data will be packed together with depositorAddress before execution.
 // If the target function parameters include reference types then the offsets should be kept consistent.
 // This function packs the parameters together with a fake address and removes the address.
-// After repacking in the handler together with depositorAddress, the offsets will be correct.
+// After repacking the data in the handler together with depositorAddress, the offsets will be correct.
 const createPermissionlessGenericExecutionData = (
   types,
   values


### PR DESCRIPTION
## Description
Currently `executionDataDepositor` address is decoded in `deposit` function on origin chain as `abi.decode` so its length is not used here and the address is read as 32 bytes (20 bytes padded with 0).
This change implements parsing of `executionDataDepositor` in the same way as `executeContractAddress`, using its length (20 bytes for EVM).

## Related Issue Or Context
We had different encodings of `executionDataDepositor` and `executeContractAddress` addresses: one of them was encoded using 32 bytes and another one was encoded using 20 bytes (for EVM chains). This change would make the encoding consistent.

Closes: #<issue>

## How Has This Been Tested? Testing details.
Unit tests were updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
