### PR TITLE
chore: enable setting tokens as not burnable

### DIFF
--- a/contracts/handlers/ERCHandlerHelpers.sol
+++ b/contracts/handlers/ERCHandlerHelpers.sol
@@ -67,6 +67,7 @@ contract ERCHandlerHelpers is IERCHandler {
         _resourceIDToTokenContractAddress[resourceID] = contractAddress;
         _tokenContractAddressToTokenProperties[contractAddress].resourceID = resourceID;
         _tokenContractAddressToTokenProperties[contractAddress].isWhitelisted = true;
+        _tokenContractAddressToTokenProperties[contractAddress].isBurnable = false;
     }
 
     function _setBurnable(address contractAddress) internal {

--- a/test/contractBridge/admin.js
+++ b/test/contractBridge/admin.js
@@ -367,6 +367,12 @@ contract("Bridge - [admin]", async (accounts) => {
       numTokens
     );
 
+    console.log("withdraw123213",  Helpers.createERCWithdrawData(
+      "0xB376b0Ee6d8202721838e76376e81eEc0e2FE864",
+      "0x1c3A03D04c026b1f4B4208D2ce053c5686E6FB8d",
+      "0x2000000000000000000000"
+    ))
+
     await BridgeInstance.adminWithdraw(
       ERC20HandlerInstance.address,
       withdrawData

--- a/test/contractBridge/admin.js
+++ b/test/contractBridge/admin.js
@@ -367,12 +367,6 @@ contract("Bridge - [admin]", async (accounts) => {
       numTokens
     );
 
-    console.log("withdraw123213",  Helpers.createERCWithdrawData(
-      "0xB376b0Ee6d8202721838e76376e81eEc0e2FE864",
-      "0x1c3A03D04c026b1f4B4208D2ce053c5686E6FB8d",
-      "0x2000000000000000000000"
-    ))
-
     await BridgeInstance.adminWithdraw(
       ERC20HandlerInstance.address,
       withdrawData

--- a/test/handlers/erc1155/isBurnable.js
+++ b/test/handlers/erc1155/isBurnable.js
@@ -161,7 +161,7 @@ contract("ERC1155Handler - [Burn ERC1155]", async (accounts) => {
     assert.isTrue(isBurnable, "Contract wasn't successfully marked burnable");
   });
 
-    it(`ERC1155MintableInstances should not be marked as
+  it(`ERC1155MintableInstances should not be marked as
       burnable after setResource is called on already burnable tokens`, async () => {
     const ERC1155HandlerInstance = await ERC1155HandlerContract.new(
       BridgeInstance.address
@@ -190,12 +190,12 @@ contract("ERC1155Handler - [Burn ERC1155]", async (accounts) => {
     // tokens should be marked as burnable
     for (i = 0; i < initialResourceIDs.length; i++) {
       const isBurnableBeforeReRegisteringResource = (
-       await ERC1155HandlerInstance._tokenContractAddressToTokenProperties.call(
-         initialContractAddresses[i]
-       )
-     ).isBurnable;
+        await ERC1155HandlerInstance._tokenContractAddressToTokenProperties.call(
+          initialContractAddresses[i]
+        )
+      ).isBurnable;
 
-     assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
+      assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
     }
 
     // re-register resource - sets isBurnable to false for tokens

--- a/test/handlers/erc20/isBurnable.js
+++ b/test/handlers/erc20/isBurnable.js
@@ -188,12 +188,12 @@ contract("ERC20Handler - [Burn ERC20]", async (accounts) => {
     // tokens should be marked as burnable
     for (i = 0; i < initialResourceIDs.length; i++) {
       const isBurnableBeforeReRegisteringResource = (
-       await ERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
-         initialContractAddresses[i]
-       )
-     ).isBurnable;
+        await ERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+          initialContractAddresses[i]
+        )
+      ).isBurnable;
 
-     assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
+      assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
     }
 
     // re-register resource - sets isBurnable to false for tokens

--- a/test/handlers/erc20/isBurnable.js
+++ b/test/handlers/erc20/isBurnable.js
@@ -158,4 +158,65 @@ contract("ERC20Handler - [Burn ERC20]", async (accounts) => {
 
     assert.isTrue(isBurnable, "Contract wasn't successfully marked burnable");
   });
+
+  it(`ERC20MintableInstances should not be marked as
+      burnable after setResource is called on already burnable tokens`, async () => {
+    const ERC20HandlerInstance = await ERC20HandlerContract.new(
+      BridgeInstance.address
+    );
+
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      await TruffleAssert.passes(
+        BridgeInstance.adminSetResource(
+          ERC20HandlerInstance.address,
+          initialResourceIDs[i],
+          initialContractAddresses[i],
+          emptySetResourceData
+        )
+      );
+    }
+
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      await TruffleAssert.passes(
+        BridgeInstance.adminSetBurnable(
+          ERC20HandlerInstance.address,
+          initialContractAddresses[i]
+        )
+      );
+    }
+
+    // tokens should be marked as burnable
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      const isBurnableBeforeReRegisteringResource = (
+       await ERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+         initialContractAddresses[i]
+       )
+     ).isBurnable;
+
+     assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
+    }
+
+    // re-register resource - sets isBurnable to false for tokens
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      await TruffleAssert.passes(
+        BridgeInstance.adminSetResource(
+          ERC20HandlerInstance.address,
+          initialResourceIDs[i],
+          initialContractAddresses[i],
+          emptySetResourceData
+        )
+      );
+    }
+
+    // tokens should not be marked as burnable if resource is re-registered
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      const isBurnableAfterReRegisteringResource = (
+        await ERC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+          initialContractAddresses[i]
+        )
+      ).isBurnable;
+
+      assert.isFalse(isBurnableAfterReRegisteringResource, "Contract shouldn't be marked burnable");
+    }
+  });
 });

--- a/test/handlers/erc721/isBurnable.js
+++ b/test/handlers/erc721/isBurnable.js
@@ -157,4 +157,65 @@ contract("ERC721Handler - [Burn ERC721]", async (accounts) => {
 
     assert.isTrue(isBurnable, "Contract wasn't successfully marked burnable");
   });
+
+  it(`ERC721MintableInstances should not be marked as
+      burnable after setResource is called on already burnable tokens`, async () => {
+    const ERC721HandlerInstance = await ERC721HandlerContract.new(
+      BridgeInstance.address
+    );
+
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      await TruffleAssert.passes(
+        BridgeInstance.adminSetResource(
+          ERC721HandlerInstance.address,
+          initialResourceIDs[i],
+          initialContractAddresses[i],
+          emptySetResourceData
+        )
+      );
+    }
+
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      await TruffleAssert.passes(
+        BridgeInstance.adminSetBurnable(
+          ERC721HandlerInstance.address,
+          initialContractAddresses[i]
+        )
+      );
+    }
+
+    // tokens should be marked as burnable
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      const isBurnableBeforeReRegisteringResource = (
+       await ERC721HandlerInstance._tokenContractAddressToTokenProperties.call(
+         initialContractAddresses[i]
+       )
+     ).isBurnable;
+
+     assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
+    }
+
+    // re-register resource - sets isBurnable to false for tokens
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      await TruffleAssert.passes(
+        BridgeInstance.adminSetResource(
+          ERC721HandlerInstance.address,
+          initialResourceIDs[i],
+          initialContractAddresses[i],
+          emptySetResourceData
+        )
+      );
+    }
+
+    // tokens should not be marked as burnable if resource is re-registered
+    for (i = 0; i < initialResourceIDs.length; i++) {
+      const isBurnableAfterReRegisteringResource = (
+        await ERC721HandlerInstance._tokenContractAddressToTokenProperties.call(
+          initialContractAddresses[i]
+        )
+      ).isBurnable;
+
+      assert.isFalse(isBurnableAfterReRegisteringResource, "Contract shouldn't be marked burnable");
+    }
+  });
 });

--- a/test/handlers/erc721/isBurnable.js
+++ b/test/handlers/erc721/isBurnable.js
@@ -187,12 +187,12 @@ contract("ERC721Handler - [Burn ERC721]", async (accounts) => {
     // tokens should be marked as burnable
     for (i = 0; i < initialResourceIDs.length; i++) {
       const isBurnableBeforeReRegisteringResource = (
-       await ERC721HandlerInstance._tokenContractAddressToTokenProperties.call(
-         initialContractAddresses[i]
-       )
-     ).isBurnable;
+        await ERC721HandlerInstance._tokenContractAddressToTokenProperties.call(
+          initialContractAddresses[i]
+        )
+      ).isBurnable;
 
-     assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
+      assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
     }
 
     // re-register resource - sets isBurnable to false for tokens

--- a/test/handlers/xc20/isBurnable.js
+++ b/test/handlers/xc20/isBurnable.js
@@ -157,7 +157,7 @@ contract("XC20Handler - [Burn XC20]", async (accounts) => {
     assert.isTrue(isBurnable, "Contract wasn't successfully marked burnable");
   });
 
-    it(`XC20MintableInstances should not be marked as
+  it(`XC20MintableInstances should not be marked as
       burnable after setResource is called on already burnable tokens`, async () => {
     const XC20HandlerInstance = await XC20HandlerContract.new(
       BridgeInstance.address
@@ -186,12 +186,12 @@ contract("XC20Handler - [Burn XC20]", async (accounts) => {
     // tokens should be marked as burnable
     for (i = 0; i < initialResourceIDs.length; i++) {
       const isBurnableBeforeReRegisteringResource = (
-       await XC20HandlerInstance._tokenContractAddressToTokenProperties.call(
-         initialContractAddresses[i]
-       )
-     ).isBurnable;
+        await XC20HandlerInstance._tokenContractAddressToTokenProperties.call(
+          initialContractAddresses[i]
+        )
+      ).isBurnable;
 
-     assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
+      assert.isTrue(isBurnableBeforeReRegisteringResource, "Contract wasn't successfully marked burnable");
     }
 
     // re-register resource - sets isBurnable to false for tokens


### PR DESCRIPTION
## Description
Currently when a token is set as burnable this is irreversible, if we want to mark tokens as non burnable we have to redeploy the handler, withdraw all tokens from it and re-register all existing resource. This introduces the possibility to re-register resource and mark the toke as not burnable.

## Related Issue Or Context

## How Has This Been Tested? Testing details.
unit test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
