### PR TITLE
feat: return data from Bridge.deposit()

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -249,10 +249,10 @@ contract Bridge is Pausable, Context, EIP712 {
         address handler = _resourceIDToHandlerAddress[resourceID];
         require(handler != address(0), "resourceID not mapped to handler");
 
-        uint64 depositNonce = ++_depositCounts[destinationDomainID];
+        depositNonce = ++_depositCounts[destinationDomainID];
 
         IHandler depositHandler = IHandler(handler);
-        bytes memory handlerResponse = depositHandler.deposit(resourceID, sender, depositData);
+        handlerResponse = depositHandler.deposit(resourceID, sender, depositData);
 
         emit Deposit(destinationDomainID, resourceID, depositNonce, sender, depositData, handlerResponse);
         return (depositNonce, handlerResponse);

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -227,12 +227,16 @@ contract Bridge is Pausable, Context, EIP712 {
         @param depositData Additional data to be passed to specified handler.
         @param feeData Additional data to be passed to the fee handler.
         @notice Emits {Deposit} event with all necessary parameters and a handler response.
+        @return depositNonce deposit nonce for the destination domain.
+        @return handlerResponse a handler response: 
         - ERC20Handler: responds with an empty data.
         - ERC721Handler: responds with the deposited token metadata acquired by calling a tokenURI method in the token contract.
         - PermissionedGenericHandler: responds with the raw bytes returned from the call to the target contract.
         - PermissionlessGenericHandler: responds with an empty data.
      */
-    function deposit(uint8 destinationDomainID, bytes32 resourceID, bytes calldata depositData, bytes calldata feeData) external payable whenNotPaused {
+    function deposit(uint8 destinationDomainID, bytes32 resourceID, bytes calldata depositData, bytes calldata feeData) 
+        external payable whenNotPaused 
+        returns (uint64 depositNonce, bytes memory handlerResponse) {
         require(destinationDomainID != _domainID, "Can't deposit to current domain");
 
         address sender = _msgSender();
@@ -251,6 +255,7 @@ contract Bridge is Pausable, Context, EIP712 {
         bytes memory handlerResponse = depositHandler.deposit(resourceID, sender, depositData);
 
         emit Deposit(destinationDomainID, resourceID, depositNonce, sender, depositData, handlerResponse);
+        return (depositNonce, handlerResponse);
     }
 
     /**

--- a/test/handlers/generic/permissionedDeposit.js
+++ b/test/handlers/generic/permissionedDeposit.js
@@ -458,4 +458,21 @@ contract("PermissionedGenericHandler - [deposit]", async (accounts) => {
       );
     });
   });
+
+  it("Bridge should return correct data from deposit tx", async () => {
+    const argument = "soylentGreenIsPeople";
+    const encodedMetaData = Helpers.abiEncode(["string"], [argument]);
+
+    const callResult = await BridgeInstance.deposit.call(
+      destinationDomainID,
+      initialResourceIDs[6],
+      Helpers.createPermissionedGenericDepositData(encodedMetaData),
+      feeData,
+      {from: depositorAddress}
+    );
+
+    const expectedMetaData = Ethers.utils.formatBytes32String(argument);
+    assert.equal(callResult.depositNonce.toNumber(), 1);
+    assert.equal(callResult.handlerResponse, expectedMetaData);
+  });
 });


### PR DESCRIPTION
Return (depositNonce, handlerResponse) from Bridge.deposit()

## Description
Bridge will return (depositNonce, handlerResponse) from Bridge.deposit(). The returned values could be used by external adapters that interact with the Bridge.

## Related Issue Or Context
#163

Closes: #163

## How Has This Been Tested? Testing details.
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
