### PR TITLE
fix: remove unnecessary visibility from constructors

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -104,7 +104,7 @@ contract Bridge is Pausable, Context, EIP712 {
         @param domainID ID of chain the Bridge contract exists on.
         @param accessControl Address of access control contract.
      */
-    constructor (uint8 domainID, address accessControl) EIP712("Bridge", "3.1.0") public {
+    constructor (uint8 domainID, address accessControl) EIP712("Bridge", "3.1.0") {
         _domainID = domainID;
         _accessControl = IAccessControlSegregator(accessControl);
 

--- a/contracts/Forwarder.sol
+++ b/contracts/Forwarder.sol
@@ -25,7 +25,7 @@ contract Forwarder is EIP712 {
 
     mapping(address => uint256) private _nonces;
 
-    constructor() EIP712("Forwarder", "0.0.1") public {}
+    constructor() EIP712("Forwarder", "0.0.1") {}
 
     function getNonce(address from) public view returns (uint256) {
         return _nonces[from];
@@ -49,7 +49,7 @@ contract Forwarder is EIP712 {
         (bool success, bytes memory returndata) = req.to.call{gas: req.gas, value: req.value}(
             abi.encodePacked(req.data, req.from)
         );
-        
+
         assert(gasleft() > req.gas / 63);
 
         return (success, returndata);

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -6,7 +6,7 @@ contract Migrations {
   address public owner;
   uint public last_completed_migration;
 
-  constructor() public {
+  constructor() {
     owner = msg.sender;
   }
 

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -61,7 +61,7 @@ contract HandlerRevert is ERCHandlerHelpers {
 
     constructor(
         address          bridgeAddress
-    ) public ERCHandlerHelpers(bridgeAddress) {
+    ) ERCHandlerHelpers(bridgeAddress) {
     }
 
     function executeProposal(bytes32, bytes calldata) external view {
@@ -163,7 +163,7 @@ contract XC20Test is ERC20 {
 contract ERC20PresetMinterPauserDecimals is ERC20PresetMinterPauser {
 
     uint8 private immutable customDecimals;
-    constructor(string memory name, string memory symbol, uint8 decimals) public ERC20PresetMinterPauser(name, symbol){
+    constructor(string memory name, string memory symbol, uint8 decimals) ERC20PresetMinterPauser(name, symbol){
         customDecimals = decimals;
     }
 
@@ -177,9 +177,9 @@ contract TestDeposit {
 
     /**
         This helper can be used to prepare execution data for Bridge.deposit() on the source chain
-        if PermissionlessGenericHandler is used 
+        if PermissionlessGenericHandler is used
         and if the target function accepts (address depositor, bytes executionData).
-        The execution data (packed as bytes) will be packed together with depositorAddress 
+        The execution data (packed as bytes) will be packed together with depositorAddress
         in PermissionlessGenericHandler before execution on the target chain.
         This function packs the bytes parameter together with a fake address and removes the address.
         After repacking in the handler together with depositorAddress, the offsets will be correct.

--- a/contracts/handlers/FeeHandlerRouter.sol
+++ b/contracts/handlers/FeeHandlerRouter.sol
@@ -41,7 +41,7 @@ contract FeeHandlerRouter is IFeeHandler, AccessControl {
     /**
         @param bridgeAddress Contract address of previously deployed Bridge.
      */
-    constructor(address bridgeAddress) public {
+    constructor(address bridgeAddress) {
         _bridgeAddress = bridgeAddress;
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }

--- a/contracts/handlers/PermissionedGenericHandler.sol
+++ b/contracts/handlers/PermissionedGenericHandler.sol
@@ -42,7 +42,7 @@ contract PermissionedGenericHandler is IHandler {
      */
     constructor(
         address          bridgeAddress
-    ) public {
+    ) {
         _bridgeAddress = bridgeAddress;
     }
 

--- a/contracts/handlers/PermissionlessGenericHandler.sol
+++ b/contracts/handlers/PermissionlessGenericHandler.sol
@@ -26,7 +26,7 @@ contract PermissionlessGenericHandler is IHandler {
      */
     constructor(
         address          bridgeAddress
-    ) public {
+    ) {
         _bridgeAddress = bridgeAddress;
     }
 
@@ -59,7 +59,7 @@ contract PermissionlessGenericHandler is IHandler {
           executionData is repacked together with executionDataDepositor address for using it in the target contract.
           If executionData contains dynamic types then it is necessary to keep the offsets correct.
           executionData should be encoded together with a 32-byte address and then passed as a parameter without that address.
-          If the target function accepts (address depositor, bytes executionData) 
+          If the target function accepts (address depositor, bytes executionData)
           then a function like the following one can be used:
 
             function prepareDepositData(bytes calldata executionData) view external returns (bytes memory) {
@@ -75,7 +75,7 @@ contract PermissionlessGenericHandler is IHandler {
 
           Another example: if the target function accepts (address depositor, uint[], address)
           then a function like the following one can be used:
-            
+
             function prepareDepositData(uint[] calldata uintArray, address addr) view external returns (bytes memory) {
                 bytes memory encoded = abi.encode(address(0), uintArray, addr);
                 return this.slice(encoded, 32);
@@ -116,7 +116,7 @@ contract PermissionlessGenericHandler is IHandler {
           executionData is repacked together with executionDataDepositor address for using it in the target contract.
           If executionData contains dynamic types then it is necessary to keep the offsets correct.
           executionData should be encoded together with a 32-byte address and then passed as a parameter without that address.
-          If the target function accepts (address depositor, bytes executionData) 
+          If the target function accepts (address depositor, bytes executionData)
           then a function like the following one can be used:
 
             function prepareDepositData(bytes calldata executionData) view external returns (bytes memory) {
@@ -133,7 +133,7 @@ contract PermissionlessGenericHandler is IHandler {
 
           Another example: if the target function accepts (address depositor, uint[], address)
           then a function like the following one can be used:
-            
+
             function prepareDepositData(uint[] calldata uintArray, address addr) view external returns (bytes memory) {
                 bytes memory encoded = abi.encode(address(0), uintArray, addr);
                 return this.slice(encoded, 32);

--- a/contracts/handlers/fee/BasicFeeHandler.sol
+++ b/contracts/handlers/fee/BasicFeeHandler.sol
@@ -41,7 +41,7 @@ contract BasicFeeHandler is IFeeHandler, AccessControl {
         @param bridgeAddress Contract address of previously deployed Bridge.
         @param feeHandlerRouterAddress Contract address of previously deployed FeeHandlerRouter.
      */
-    constructor(address bridgeAddress, address feeHandlerRouterAddress) public {
+    constructor(address bridgeAddress, address feeHandlerRouterAddress) {
         _bridgeAddress = bridgeAddress;
         _feeHandlerRouterAddress = feeHandlerRouterAddress;
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);

--- a/contracts/utils/AccessControlSegregator.sol
+++ b/contracts/utils/AccessControlSegregator.sol
@@ -19,7 +19,7 @@ contract AccessControlSegregator {
         @param functions List of functions to be granted access to.
         @param accounts List of accounts.
     */
-    constructor(bytes4[] memory functions, address[] memory accounts) public {
+    constructor(bytes4[] memory functions, address[] memory accounts) {
         require(accounts.length == functions.length, "array length should be equal");
 
         _grantAccess(GRANT_ACCESS_SIG, msg.sender);


### PR DESCRIPTION
## Description
Removes unnecessary `public` visibility from constructors, visibility for constructors has been deprecated.

## Related Issue Or Context
Closes: #170 

## How Has This Been Tested? Testing details.
manual review

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
