### PR TITLE
fix: set owner variable as immutable

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.11;
 
 contract Migrations {
-  address public owner;
+  address public immutable owner;
   uint public last_completed_migration;
 
   constructor() public {


### PR DESCRIPTION
## Description
Since `owner` variable is set in constructor and never changed set it as `immutable` to save on gas.

## Related Issue Or Context
Closes: #176 

## How Has This Been Tested? Testing details.
manual review

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
