### PR TITLE
fix: check successful transfer when minting XC20 tokens

### DIFF
--- a/contracts/ERC20Safe.sol
+++ b/contracts/ERC20Safe.sol
@@ -65,7 +65,7 @@ contract ERC20Safe {
         @param to Address to transfer token to
         @param value Amount of token to transfer
      */
-    function _safeTransfer(IERC20 token, address to, uint256 value) private {
+    function _safeTransfer(IERC20 token, address to, uint256 value) internal {
         _safeCall(token, abi.encodeWithSelector(token.transfer.selector, to, value));
     }
 
@@ -90,7 +90,7 @@ contract ERC20Safe {
         uint256 tokenSize;
         assembly {
             tokenSize := extcodesize(token)
-        }         
+        }
         require(tokenSize > 0, "ERC20: not a contract");
 
         (bool success, bytes memory returndata) = address(token).call(data);

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -160,17 +160,6 @@ contract XC20Test is ERC20 {
     }
 }
 
-/**
-  @dev This contract mocks XC20Test where "transfer()" always fails
- */
-contract XC20TestMock is XC20Test {
-    function transfer(address to, uint256 amount) public virtual override returns (bool) {
-        address owner = _msgSender();
-        _transfer(owner, to, amount);
-        return false;
-  }
-}
-
 contract ERC20PresetMinterPauserDecimals is ERC20PresetMinterPauser {
 
     uint8 private immutable customDecimals;

--- a/contracts/TestContracts.sol
+++ b/contracts/TestContracts.sol
@@ -160,6 +160,17 @@ contract XC20Test is ERC20 {
     }
 }
 
+/**
+  @dev This contract mocks XC20Test where "transfer()" always fails
+ */
+contract XC20TestMock is XC20Test {
+    function transfer(address to, uint256 amount) public virtual override returns (bool) {
+        address owner = _msgSender();
+        _transfer(owner, to, amount);
+        return false;
+  }
+}
+
 contract ERC20PresetMinterPauserDecimals is ERC20PresetMinterPauser {
 
     uint8 private immutable customDecimals;
@@ -177,9 +188,9 @@ contract TestDeposit {
 
     /**
         This helper can be used to prepare execution data for Bridge.deposit() on the source chain
-        if PermissionlessGenericHandler is used 
+        if PermissionlessGenericHandler is used
         and if the target function accepts (address depositor, bytes executionData).
-        The execution data (packed as bytes) will be packed together with depositorAddress 
+        The execution data (packed as bytes) will be packed together with depositorAddress
         in PermissionlessGenericHandler before execution on the target chain.
         This function packs the bytes parameter together with a fake address and removes the address.
         After repacking in the handler together with depositorAddress, the offsets will be correct.

--- a/contracts/XC20Safe.sol
+++ b/contracts/XC20Safe.sol
@@ -33,7 +33,6 @@ contract XC20Safe is ERC20Safe {
     function mintERC20(address tokenAddress, address recipient, uint256 amount) internal override {
         IERC20Plus xc20 = IERC20Plus(tokenAddress);
         xc20.mint(address(this), amount);
-        (bool success) = xc20.transfer(recipient, amount);
-        require(success, "XC20: failed to transfer tokens to recipient");
+        _safeTransfer(xc20, recipient, amount);
     }
 }

--- a/contracts/XC20Safe.sol
+++ b/contracts/XC20Safe.sol
@@ -33,6 +33,7 @@ contract XC20Safe is ERC20Safe {
     function mintERC20(address tokenAddress, address recipient, uint256 amount) internal override {
         IERC20Plus xc20 = IERC20Plus(tokenAddress);
         xc20.mint(address(this), amount);
-        xc20.transfer(recipient, amount);
+        (bool success) = xc20.transfer(recipient, amount);
+        require(success, "XC20: failed to transfer tokens to recipient");
     }
 }

--- a/test/contractBridge/executeProposalXC20.js
+++ b/test/contractBridge/executeProposalXC20.js
@@ -9,7 +9,6 @@ const Ethers = require("ethers");
 const Helpers = require("../helpers");
 
 const XC20TestContract = artifacts.require("XC20Test");
-const XC20TestContractMock = artifacts.require("XC20TestMock");
 const XC20HandlerContract = artifacts.require("XC20Handler");
 
 contract("Bridge - [execute proposal - XC20]", async (accounts) => {
@@ -29,11 +28,9 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
 
   let BridgeInstance;
   let XC20TestInstance;
-  let XC20TestMockInstance;
   let XC20HandlerInstance;
 
-  let resourceID1;
-  let resourceID2;
+  let resourceID;
   let depositData;
   let depositProposalData;
 
@@ -48,25 +45,19 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
         adminAddress
       )),
       XC20TestContract.new().then(
-        (instance) => (XC20TestInstance = instance)
+        (instance) => (OriginXC20TestInstance = instance)
       ),
-      XC20TestContractMock.new().then(
-        (instance) => (XC20TestMockInstance = instance)
-      )
     ]);
 
-    await Promise.all([
-      resourceID1 = Helpers.createResourceID(
+    await XC20TestContract.new().then(
+      (instance) => (XC20TestInstance = instance)
+    ),
+      (resourceID = Helpers.createResourceID(
         XC20TestInstance.address,
         destinationDomainID
-      ),
-      resourceID2 = Helpers.createResourceID(
-        XC20TestMockInstance.address,
-        destinationDomainID
-      )
-    ]);
+      ));
 
-    initialResourceIDs = [resourceID1, resourceID2];
+    initialResourceIDs = [resourceID];
     initialContractAddresses = [XC20TestInstance.address];
     burnableContractAddresses = [];
 
@@ -75,21 +66,11 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
     await Promise.all([
       BridgeInstance.adminSetResource(
         XC20HandlerInstance.address,
-        initialResourceIDs[0],
+        resourceID,
         XC20TestInstance.address,
         emptySetResourceData
       ),
       XC20TestInstance.mint(
-        depositorAddress,
-        initialTokenAmount
-      ),
-      BridgeInstance.adminSetResource(
-        XC20HandlerInstance.address,
-        initialResourceIDs[1],
-        XC20TestMockInstance.address,
-        emptySetResourceData
-      ),
-      XC20TestMockInstance.mint(
         depositorAddress,
         initialTokenAmount
       ),
@@ -98,11 +79,6 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
     await BridgeInstance.adminSetBurnable(
       XC20HandlerInstance.address,
       XC20TestInstance.address
-    );
-
-    await BridgeInstance.adminSetBurnable(
-      XC20HandlerInstance.address,
-      XC20TestMockInstance.address
     );
 
     data = Helpers.createERCDepositData(depositAmount, 20, recipientAddress);
@@ -131,7 +107,7 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
     proposal = {
       originDomainID: originDomainID,
       depositNonce: expectedDepositNonce,
-      resourceID: initialResourceIDs[0],
+      resourceID: resourceID,
       data: depositProposalData,
     };
 
@@ -163,7 +139,7 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
       await TruffleAssert.passes(
         BridgeInstance.deposit(
           originDomainID,
-          initialResourceIDs[0],
+          resourceID,
           depositData,
           feeData,
           {from: depositorAddress}
@@ -202,7 +178,7 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
       await TruffleAssert.passes(
         BridgeInstance.deposit(
           originDomainID,
-          initialResourceIDs[0],
+          resourceID,
           depositData,
           feeData,
           {from: depositorAddress}
@@ -236,7 +212,7 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
       await TruffleAssert.passes(
         BridgeInstance.deposit(
           originDomainID,
-          initialResourceIDs[0],
+          resourceID,
           depositData,
           feeData,
           {from: depositorAddress}
@@ -285,7 +261,7 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
       await TruffleAssert.passes(
         BridgeInstance.deposit(
           originDomainID,
-          initialResourceIDs[0],
+          resourceID,
           depositData,
           feeData,
           {from: depositorAddress}
@@ -331,7 +307,7 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
       await TruffleAssert.passes(
         BridgeInstance.deposit(
           originDomainID,
-          initialResourceIDs[0],
+          resourceID,
           depositData,
           feeData,
           {from: depositorAddress}
@@ -370,7 +346,7 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
       await TruffleAssert.passes(
         BridgeInstance.deposit(
           originDomainID,
-          initialResourceIDs[0],
+          resourceID,
           depositData,
           feeData,
           {from: depositorAddress}
@@ -404,7 +380,7 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
       await TruffleAssert.passes(
         BridgeInstance.deposit(
           originDomainID,
-          initialResourceIDs[0],
+          resourceID,
           depositData,
           feeData,
           {from: depositorAddress}
@@ -453,7 +429,7 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
       await TruffleAssert.passes(
         BridgeInstance.deposit(
           originDomainID,
-          initialResourceIDs[0],
+          resourceID,
           depositData,
           feeData,
           {from: depositorAddress}
@@ -467,145 +443,74 @@ contract("Bridge - [execute proposal - XC20]", async (accounts) => {
         "Invalid proposal signer"
       );
     });
+  });
 
-    it(`transfer event should be emitted with expected values when executing proposal -
-        mint to handler and then transfer to recipient`, async () => {
-      const proposalSignedData = await Helpers.signTypedProposal(
-        BridgeInstance.address,
-        [proposal]
-      );
+  it(`transfer event should be emitted with expected values when executing proposal -
+      mint to handler and then transfer to recipient`, async () => {
+    const proposalSignedData = await Helpers.signTypedProposal(
+      BridgeInstance.address,
+      [proposal]
+    );
 
-      // depositorAddress makes initial deposit of depositAmount
-      assert.isFalse(await BridgeInstance.paused());
-      await TruffleAssert.passes(
-        BridgeInstance.deposit(
-          originDomainID,
-          initialResourceIDs[0],
-          depositData,
-          feeData,
-          {from: depositorAddress}
-        )
-      );
-
-      const proposalTx = await BridgeInstance.executeProposal(
-        proposal,
-        proposalSignedData,
-        {from: relayer1Address}
-      );
-
-      TruffleAssert.eventEmitted(proposalTx, "ProposalExecution", (event) => {
-        return (
-          event.originDomainID.toNumber() === originDomainID &&
-          event.depositNonce.toNumber() === expectedDepositNonce &&
-          event.dataHash === dataHash
-        );
-      });
-
-      const internalTx = await TruffleAssert.createTransactionResult(
-        XC20TestInstance,
-        proposalTx.tx
-      );
-
-      // check that tokens are minted to handler
-      TruffleAssert.eventEmitted(internalTx, "Transfer", (event) => {
-        return (
-          event.from === Ethers.constants.AddressZero &&
-          event.to === XC20HandlerInstance.address &&
-          event.value.toNumber() === depositAmount
-        );
-      });
-
-      // check that tokens are transferred from handler to recipient
-      TruffleAssert.eventEmitted(internalTx, "Transfer", (event) => {
-        return (
-          event.from === XC20HandlerInstance.address &&
-          event.to === recipientAddress &&
-          event.value.toNumber() === depositAmount
-        );
-      });
-
-      // check that deposit nonce has been marked as used in bitmap
-      assert.isTrue(
-        await BridgeInstance.isProposalExecuted(
-          originDomainID,
-          expectedDepositNonce
-        )
-      );
-
-      // check that tokens are transferred to recipient address
-      const recipientBalance = await XC20TestInstance.balanceOf(recipientAddress);
-      assert.strictEqual(recipientBalance.toNumber(), depositAmount);
-    });
-
-    it("executeProposal should revert if transferring tokens from XC20Safe to recipient fails", async () => {
-      const failingProposal = {
-        originDomainID: originDomainID,
-        depositNonce: expectedDepositNonce,
-        resourceID: initialResourceIDs[1],
-        data: depositData,
-      };
-
-      const proposalSignedData = await Helpers.signTypedProposal(
-        BridgeInstance.address,
-        [failingProposal]
-      );
-
-      await BridgeInstance.deposit(
+    // depositorAddress makes initial deposit of depositAmount
+    assert.isFalse(await BridgeInstance.paused());
+    await TruffleAssert.passes(
+      BridgeInstance.deposit(
         originDomainID,
-        initialResourceIDs[1],
+        resourceID,
         depositData,
         feeData,
         {from: depositorAddress}
+      )
+    );
+
+    const proposalTx = await BridgeInstance.executeProposal(
+      proposal,
+      proposalSignedData,
+      {from: relayer1Address}
+    );
+
+    TruffleAssert.eventEmitted(proposalTx, "ProposalExecution", (event) => {
+      return (
+        event.originDomainID.toNumber() === originDomainID &&
+        event.depositNonce.toNumber() === expectedDepositNonce &&
+        event.dataHash === dataHash
       );
-
-      const depositProposalBeforeFailedExecute =
-        await BridgeInstance.isProposalExecuted(
-          originDomainID,
-          expectedDepositNonce
-        );
-
-      // depositNonce is not used
-      assert.isFalse(depositProposalBeforeFailedExecute);
-
-      // recipient balance before proposal execution is 0
-      const recipientBalanceBeforeFailedExecute = await XC20TestMockInstance.balanceOf(recipientAddress);
-      assert.strictEqual(
-        recipientBalanceBeforeFailedExecute.toNumber(),
-        0
-      );
-
-      const executeTx = await BridgeInstance.executeProposal(
-        failingProposal,
-        proposalSignedData,
-        {from: relayer1Address}
-      );
-
-      TruffleAssert.eventEmitted(executeTx, "FailedHandlerExecution", (event) => {
-        return (
-          event.originDomainID.toNumber() === originDomainID &&
-          event.depositNonce.toNumber() === expectedDepositNonce &&
-          Ethers.utils.toUtf8String(
-            // slice from handler response bytes containing the revert reason
-            "0x" + event.lowLevelData.slice(138, 226)
-          ) === "XC20: failed to transfer tokens to recipient"
-        );
-      });
-
-      const recipientBalanceAfterFailedExecute = await XC20TestMockInstance.balanceOf(recipientAddress);
-      assert.strictEqual(
-        recipientBalanceAfterFailedExecute.toNumber(),
-        0
-      );
-
-      // recipient balance after proposal execution hasn't changed
-      const depositProposalAfterFailedExecute =
-        await BridgeInstance.isProposalExecuted(
-          originDomainID,
-          expectedDepositNonce
-        );
-
-      // depositNonce is not used
-      assert.isFalse(depositProposalAfterFailedExecute);
     });
+
+    const internalTx = await TruffleAssert.createTransactionResult(
+      XC20TestInstance,
+      proposalTx.tx
+    );
+
+    // check that tokens are minted to handler
+    TruffleAssert.eventEmitted(internalTx, "Transfer", (event) => {
+      return (
+        event.from === Ethers.constants.AddressZero &&
+        event.to === XC20HandlerInstance.address &&
+        event.value.toNumber() === depositAmount
+      );
+    });
+
+    // check that tokens are transferred from handler to recipient
+    TruffleAssert.eventEmitted(internalTx, "Transfer", (event) => {
+      return (
+        event.from === XC20HandlerInstance.address &&
+        event.to === recipientAddress &&
+        event.value.toNumber() === depositAmount
+      );
+    });
+
+    // check that deposit nonce has been marked as used in bitmap
+    assert.isTrue(
+      await BridgeInstance.isProposalExecuted(
+        originDomainID,
+        expectedDepositNonce
+      )
+    );
+
+    // check that tokens are transferred to recipient address
+    const recipientBalance = await XC20TestInstance.balanceOf(recipientAddress);
+    assert.strictEqual(recipientBalance.toNumber(), depositAmount);
   });
 });


### PR DESCRIPTION
## Description
Use `_safeTransfer()` insead of `transfer()` to prevent  failed transfers, but `mintERC20` successful.

## Related Issue Or Context
Closes: #168 

## How Has This Been Tested? Testing details.
unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
