### PR TITLE
feat: add support for different fees per dest domain to basic/percentage fee handler

### DIFF
--- a/contracts/handlers/fee/BasicFeeHandler.sol
+++ b/contracts/handlers/fee/BasicFeeHandler.sol
@@ -72,8 +72,9 @@ contract BasicFeeHandler is IFeeHandler, AccessControl {
         @param feeData Additional data to be passed to the fee handler.
      */
     function collectFee(address sender, uint8 fromDomainID, uint8 destinationDomainID, bytes32 resourceID, bytes calldata depositData, bytes calldata feeData) virtual payable external onlyBridgeOrRouter {
-        if (msg.value != _domainResourceIDToFee[destinationDomainID][resourceID]) revert IncorrectFeeSupplied(msg.value);
-        emit FeeCollected(sender, fromDomainID, destinationDomainID, resourceID, _domainResourceIDToFee[destinationDomainID][resourceID], address(0));
+        uint256 currentFee = _domainResourceIDToFee[destinationDomainID][resourceID];
+        if (msg.value != currentFee) revert IncorrectFeeSupplied(msg.value);
+        emit FeeCollected(sender, fromDomainID, destinationDomainID, resourceID, currentFee, address(0));
     }
 
      /**
@@ -98,7 +99,8 @@ contract BasicFeeHandler is IFeeHandler, AccessControl {
         @param newFee Value to which fee will be updated to for the provided {destinantionDomainID} and {resourceID}.
      */
     function changeFee(uint8 destinationDomainID, bytes32 resourceID, uint256 newFee) external onlyAdmin {
-        require(_domainResourceIDToFee[destinationDomainID][resourceID] != newFee, "Current fee is equal to new fee");
+        uint256 currentFee = _domainResourceIDToFee[destinationDomainID][resourceID];
+        require(currentFee != newFee, "Current fee is equal to new fee");
         _domainResourceIDToFee[destinationDomainID][resourceID] = newFee;
         emit FeeChanged(newFee);
     }

--- a/contracts/handlers/fee/PercentageERC20FeeHandlerEVM.sol
+++ b/contracts/handlers/fee/PercentageERC20FeeHandlerEVM.sol
@@ -16,7 +16,7 @@ contract PercentageERC20FeeHandlerEVM is BasicFeeHandler, ERC20Safe {
     uint32 public constant HUNDRED_PERCENT = 1e8;
 
     /**
-        @notice _fee inherited from BasicFeeHandler in this implementation is
+        @notice _domainResourceIDToFee[destinationDomainID][resourceID] inherited from BasicFeeHandler in this implementation is
         in BPS and should be multiplied by 10000 to avoid precision loss
      */
     struct Bounds {
@@ -61,7 +61,7 @@ contract PercentageERC20FeeHandlerEVM is BasicFeeHandler, ERC20Safe {
 
         (uint256 depositAmount) = abi.decode(depositData, (uint256));
 
-        fee = depositAmount * _fee / HUNDRED_PERCENT; // 10000 for BPS and 10000 to avoid precision loss
+        fee = depositAmount * _domainResourceIDToFee[destinationDomainID][resourceID] / HUNDRED_PERCENT; // 10000 for BPS and 10000 to avoid precision loss
 
         if (fee < bounds.lowerBound) {
             fee = bounds.lowerBound;

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,8 +1,6 @@
 // The Licensed Work is (c) 2022 Sygma
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const Ethers = require("ethers");
-
 const Helpers = require("../test/helpers");
 const Utils = require("./utils");
 
@@ -18,7 +16,6 @@ const PermissionedGenericHandlerContract = artifacts.require(
 );
 const FeeRouterContract = artifacts.require("FeeHandlerRouter");
 const BasicFeeHandlerContract = artifacts.require("BasicFeeHandler");
-const DynamicFeeHandlerContract = artifacts.require("DynamicERC20FeeHandlerEVM");
 const PercentageFeeHandler = artifacts.require("PercentageERC20FeeHandlerEVM");
 
 module.exports = async function (deployer, network) {
@@ -68,40 +65,11 @@ module.exports = async function (deployer, network) {
     bridgeInstance.address,
     feeRouterInstance.address
   );
-  const dynamicFeeHandlerInstance = await deployer.deploy(
-    DynamicFeeHandlerContract,
-    bridgeInstance.address,
-    feeRouterInstance.address
-  );
   const percentageFeeHandlerInstance = await deployer.deploy(
     PercentageFeeHandler,
     bridgeInstance.address,
     feeRouterInstance.address
   )
-
-  // setup fee router and fee handlers
-  await bridgeInstance.adminChangeFeeHandler(feeRouterInstance.address);
-  if(Object.keys(currentNetworkConfig.fee.oracle).length != 0){
-    await dynamicFeeHandlerInstance.setFeeOracle(
-      currentNetworkConfig.fee.oracle.address
-    );
-    await dynamicFeeHandlerInstance.setFeeProperties(
-      currentNetworkConfig.fee.oracle.gasUsed,
-      currentNetworkConfig.fee.oracle.feePercentage
-    );
-  }
-
-  if(Object.keys(currentNetworkConfig.fee.basic).length != 0) {
-    await basicFeeHandlerInstance.changeFee(
-      Ethers.utils.parseEther(currentNetworkConfig.fee.basic.fee).toString()
-    );
-  }
-
-  if(Object.keys(currentNetworkConfig.fee.percentage).length != 0) {
-    await percentageFeeHandlerInstance.changeFee(
-      currentNetworkConfig.fee.percentage.fee
-    );
-  }
 
   console.table({
     "Deployer Address": deployerAddress,
@@ -111,7 +79,6 @@ module.exports = async function (deployer, network) {
     "ERC721Handler Address": erc721HandlerInstance.address,
     "FeeRouterContract Address": feeRouterInstance.address,
     "BasicFeeHandler Address": basicFeeHandlerInstance.address,
-    "DynamicFeeHandler Address": dynamicFeeHandlerInstance.address,
     "PercentageFeeHandler Address": percentageFeeHandlerInstance.address
   });
 
@@ -123,22 +90,6 @@ module.exports = async function (deployer, network) {
       bridgeInstance,
       erc20HandlerInstance
     );
-    await Utils.setupFee(
-      networksConfig,
-      feeRouterInstance,
-      dynamicFeeHandlerInstance,
-      basicFeeHandlerInstance,
-      percentageFeeHandlerInstance,
-      erc20
-    );
-
-  if(Object.keys(currentNetworkConfig.fee.percentage).length != 0) {
-    await percentageFeeHandlerInstance.changeFeeBounds(
-      erc20.resourceID,
-      Ethers.utils.parseEther(currentNetworkConfig.fee.percentage.lowerBound).toString(),
-      Ethers.utils.parseEther(currentNetworkConfig.fee.percentage.upperBound).toString()
-    );
-  }
 
     console.log(
       "-------------------------------------------------------------------------------"
@@ -158,14 +109,6 @@ module.exports = async function (deployer, network) {
       erc721,
       bridgeInstance,
       erc721HandlerInstance
-    );
-    await Utils.setupFee(
-      networksConfig,
-      feeRouterInstance,
-      dynamicFeeHandlerInstance,
-      basicFeeHandlerInstance,
-      percentageFeeHandlerInstance,
-      erc721
     );
 
     console.log(
@@ -191,14 +134,6 @@ module.exports = async function (deployer, network) {
         generic,
         bridgeInstance,
         permissionedGenericHandlerInstance
-      );
-      await Utils.setupFee(
-        networksConfig,
-        feeRouterInstance,
-        dynamicFeeHandlerInstance,
-        basicFeeHandlerInstance,
-        percentageFeeHandlerInstance,
-        generic
       );
 
       console.log(

--- a/migrations/3_deploy_permissionlessGenericHandler.js
+++ b/migrations/3_deploy_permissionlessGenericHandler.js
@@ -8,10 +8,6 @@ const BridgeContract = artifacts.require("Bridge");
 const PermissionlessGenericHandlerContract = artifacts.require(
   "PermissionlessGenericHandler"
 );
-const FeeRouterContract = artifacts.require("FeeHandlerRouter");
-const BasicFeeHandlerContract = artifacts.require("BasicFeeHandler");
-const PercentageFeeHandler = artifacts.require("PercentageERC20FeeHandlerEVM");
-const DynamicGenericFeeHandlerEVMContract = artifacts.require("DynamicGenericFeeHandlerEVM");
 
 module.exports = async function (deployer, network) {
   const networksConfig = Utils.getNetworksConfig();
@@ -25,22 +21,12 @@ module.exports = async function (deployer, network) {
   ) {
   // fetch deployed contracts addresses
   const bridgeInstance = await BridgeContract.deployed();
-  const feeRouterInstance = await FeeRouterContract.deployed();
-  const basicFeeHandlerInstance = await BasicFeeHandlerContract.deployed();
-  const percentageFeeHandlerInstance = await PercentageFeeHandler.deployed();
 
   // deploy generic handler
   const permissionlessGenericHandlerInstance = await deployer.deploy(
     PermissionlessGenericHandlerContract,
     bridgeInstance.address
   );
-
-  // deploy generic dynamic fee handler
-  const dynamicFeeHandlerInstance = await deployer.deploy(
-    DynamicGenericFeeHandlerEVMContract,
-    bridgeInstance.address,
-    feeRouterInstance.address
-  )
 
   console.log(
     "-------------------------------------------------------------------------------"
@@ -71,14 +57,6 @@ module.exports = async function (deployer, network) {
       currentNetworkConfig.permissionlessGeneric.resourceID,
       bridgeInstance.address,
       genericHandlerSetResourceData
-    );
-    await Utils.setupFee(
-      networksConfig,
-      feeRouterInstance,
-      dynamicFeeHandlerInstance,
-      basicFeeHandlerInstance,
-      percentageFeeHandlerInstance,
-      currentNetworkConfig.permissionlessGeneric
     );
   }
 };

--- a/migrations/4_deploy_xc20_contracts.js
+++ b/migrations/4_deploy_xc20_contracts.js
@@ -5,10 +5,6 @@ const Utils = require("./utils");
 
 const BridgeContract = artifacts.require("Bridge");
 const XC20HandlerContract = artifacts.require("XC20Handler");
-const FeeRouterContract = artifacts.require("FeeHandlerRouter");
-const BasicFeeHandlerContract = artifacts.require("BasicFeeHandler");
-const DynamicFeeHandlerContract = artifacts.require("DynamicERC20FeeHandlerEVM");
-const PercentageFeeHandler = artifacts.require("PercentageERC20FeeHandlerEVM");
 
 
 module.exports = async function (deployer, network) {
@@ -27,11 +23,6 @@ module.exports = async function (deployer, network) {
 
   // fetch deployed contracts addresses
   const bridgeInstance = await BridgeContract.deployed();
-  const feeRouterInstance = await FeeRouterContract.deployed();
-  const basicFeeHandlerInstance = await BasicFeeHandlerContract.deployed();
-  const dynamicFeeHandlerInstance =
-    await DynamicFeeHandlerContract.deployed();
-  const percentageFeeHandlerInstance = await PercentageFeeHandler.deployed();
 
   // deploy XC20 contracts
   await deployer.deploy(XC20HandlerContract, bridgeInstance.address);
@@ -40,14 +31,6 @@ module.exports = async function (deployer, network) {
   // setup xc20 tokens
   for (const xc20 of currentNetworkConfig.xc20) {
     await Utils.setupErc20(deployer, xc20, bridgeInstance, xc20HandlerInstance);
-    await Utils.setupFee(
-      networksConfig,
-      feeRouterInstance,
-      dynamicFeeHandlerInstance,
-      basicFeeHandlerInstance,
-      percentageFeeHandlerInstance,
-      xc20
-    );
 
     console.log(
       "-------------------------------------------------------------------------------"

--- a/migrations/5_renounceAdmin.js
+++ b/migrations/5_renounceAdmin.js
@@ -8,7 +8,7 @@ const AccessControlSegregatorContract = artifacts.require(
 );
 const FeeRouterContract = artifacts.require("FeeHandlerRouter");
 const BasicFeeHandlerContract = artifacts.require("BasicFeeHandler");
-const DynamicFeeHandlerContract = artifacts.require("DynamicERC20FeeHandlerEVM");
+const PercentageFeeHandlerContract = artifacts.require("PercentageERC20FeeHandlerEVM");
 
 module.exports = async function (deployer, network) {
   const networksConfig = Utils.getNetworksConfig();
@@ -21,8 +21,7 @@ module.exports = async function (deployer, network) {
     await AccessControlSegregatorContract.deployed();
   const feeRouterInstance = await FeeRouterContract.deployed();
   const basicFeeHandlerInstance = await BasicFeeHandlerContract.deployed();
-  const dynamicFeeHandlerInstance =
-    await DynamicFeeHandlerContract.deployed();
+  const percentageFeeHandlerInstance = await PercentageFeeHandlerContract.deployed();
 
   if (currentNetworkConfig.access.feeHandlerAdmin) {
     console.log(
@@ -33,7 +32,7 @@ module.exports = async function (deployer, network) {
     await basicFeeHandlerInstance.renounceAdmin(
       currentNetworkConfig.access.feeHandlerAdmin
     );
-    await dynamicFeeHandlerInstance.renounceAdmin(
+    await percentageFeeHandlerInstance.renounceAdmin(
       currentNetworkConfig.access.feeHandlerAdmin
     );
   }

--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 // The Licensed Work is (c) 2022 Sygma
 // SPDX-License-Identifier: LGPL-3.0-only
 
@@ -17,12 +18,6 @@ const DEFAULT_CONFIG_PATH = "./migrations/local.json";
 const emptySetResourceData = "0x";
 const erc20TokenAmount = Ethers.utils.parseUnits("1000", 18);
 
-const FeeType = {
-  ORACLE: "oracle",
-  BASIC: "basic",
-  PERCENTAGE: "PERCENTAGE"
-}
-
 function getNetworksConfig() {
   let path = parseArgs(process.argv.slice(2))["file"];
   if (path == undefined) {
@@ -30,37 +25,6 @@ function getNetworksConfig() {
   }
 
   return JSON.parse(fs.readFileSync(path));
-}
-
-async function setupFee(
-  networksConfig,
-  feeRouterInstance,
-  dynamicFeeHandlerInstance,
-  basicFeeHandlerInstance,
-  percentageFeeHandlerInstance,
-  token
-) {
-  for await (const network of Object.values(networksConfig)) {
-    if (token.feeType == FeeType.ORACLE) {
-      await feeRouterInstance.adminSetResourceHandler(
-        network.domainID,
-        token.resourceID,
-        dynamicFeeHandlerInstance.address
-      );
-    } else if (token.feeType == FeeType.BASIC) {
-      await feeRouterInstance.adminSetResourceHandler(
-        network.domainID,
-        token.resourceID,
-        basicFeeHandlerInstance.address
-      );
-    } else if (token.feeType == FeeType.PERCENTAGE) {
-      await feeRouterInstance.adminSetResourceHandler(
-        network.domainID,
-        token.resourceID,
-        percentageFeeHandlerInstance.address
-      )
-    }
-  }
 }
 
 async function setupErc20(
@@ -259,12 +223,11 @@ async function getDeployerAddress(deployer) {
 }
 
 module.exports = {
-  setupFee,
   setupErc20,
   setupErc721,
   setupGeneric,
   getNetworksConfig,
   migrateToNewTokenHandler,
   redeployHandler,
-  getDeployerAddress
-};
+  getDeployerAddress,
+}

--- a/test/handlers/fee/basic/calculateFee.js
+++ b/test/handlers/fee/basic/calculateFee.js
@@ -87,7 +87,7 @@ contract("BasicFeeHandler - [calculateFee]", async (accounts) => {
 
     assert.equal(web3.utils.fromWei(res[0], "ether"), "0");
     // Change fee to 0.5 ether
-    await BasicFeeHandlerInstance.changeFee(Ethers.utils.parseEther("0.5"));
+    await BasicFeeHandlerInstance.changeFee(destinationDomainID, resourceID, Ethers.utils.parseEther("0.5"));
     res = await FeeHandlerRouterInstance.calculateFee.call(
       relayer,
       originDomainID,

--- a/test/handlers/fee/basic/collectFee.js
+++ b/test/handlers/fee/basic/collectFee.js
@@ -146,7 +146,7 @@ contract("BasicFeeHandler - [collectFee]", async (accounts) => {
 
   it("deposit should revert if invalid fee amount supplied", async () => {
     // current fee is set to 0
-    assert.equal(await ERC20BasicFeeHandlerInstance._fee.call(), 0);
+    assert.equal(await ERC20BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc20ResourceID), 0);
     const incorrectFee = Ethers.utils.parseEther("1.0");
 
     const errorValues = await Helpers.expectToRevertWithCustomError(
@@ -169,12 +169,12 @@ contract("BasicFeeHandler - [collectFee]", async (accounts) => {
   it("deposit should pass if valid fee amount supplied for ERC20 deposit", async () => {
     const fee = Ethers.utils.parseEther("0.5");
     // current fee is set to 0
-    assert.equal(await ERC20BasicFeeHandlerInstance._fee.call(), 0);
+    assert.equal(await ERC20BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc20ResourceID), 0);
     // Change fee to 0.5 ether
-    await ERC20BasicFeeHandlerInstance.changeFee(fee);
+    await ERC20BasicFeeHandlerInstance.changeFee(destinationDomainID, erc20ResourceID, fee);
     assert.equal(
       web3.utils.fromWei(
-        await ERC20BasicFeeHandlerInstance._fee.call(),
+        await ERC20BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc20ResourceID),
         "ether"
       ),
       "0.5"
@@ -224,12 +224,12 @@ contract("BasicFeeHandler - [collectFee]", async (accounts) => {
   it("deposit should pass if valid fee amount supplied for ERC721 deposit", async () => {
     const fee = Ethers.utils.parseEther("0.4");
     // current fee is set to 0
-    assert.equal(await ERC721BasicFeeHandlerInstance._fee.call(), 0);
+    assert.equal(await ERC721BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc721ResourceID), 0);
     // Change fee to 0.4 ether
-    await ERC721BasicFeeHandlerInstance.changeFee(fee);
+    await ERC721BasicFeeHandlerInstance.changeFee(destinationDomainID, erc721ResourceID, fee);
     assert.equal(
       web3.utils.fromWei(
-        await ERC721BasicFeeHandlerInstance._fee.call(),
+        await ERC721BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc721ResourceID),
         "ether"
       ),
       "0.4"
@@ -314,12 +314,12 @@ contract("BasicFeeHandler - [collectFee]", async (accounts) => {
       ERC20BasicFeeHandlerInstance.address
     );
     // current fee is set to 0
-    assert.equal(await ERC20BasicFeeHandlerInstance._fee.call(), 0);
+    assert.equal(await ERC20BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc20ResourceID), 0);
     // Change fee to 0.5 ether
-    await ERC20BasicFeeHandlerInstance.changeFee(fee);
+    await ERC20BasicFeeHandlerInstance.changeFee(destinationDomainID, erc20ResourceID, fee);
     assert.equal(
       web3.utils.fromWei(
-        await ERC20BasicFeeHandlerInstance._fee.call(),
+        await ERC20BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc20ResourceID),
         "ether"
       ),
       "0.5"
@@ -357,12 +357,12 @@ contract("BasicFeeHandler - [collectFee]", async (accounts) => {
       ERC20BasicFeeHandlerInstance.address
     );
     // current fee is set to 0
-    assert.equal(await ERC20BasicFeeHandlerInstance._fee.call(), 0);
+    assert.equal(await ERC20BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc20ResourceID), 0);
     // Change fee to 0.5 ether
-    await ERC20BasicFeeHandlerInstance.changeFee(fee);
+    await ERC20BasicFeeHandlerInstance.changeFee(destinationDomainID, erc20ResourceID, fee);
     assert.equal(
       web3.utils.fromWei(
-        await ERC20BasicFeeHandlerInstance._fee.call(),
+        await ERC20BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc20ResourceID),
         "ether"
       ),
       "0.5"
@@ -403,12 +403,12 @@ contract("BasicFeeHandler - [collectFee]", async (accounts) => {
 
     const fee = Ethers.utils.parseEther("0.5");
     // current fee is set to 0
-    assert.equal(await ERC20BasicFeeHandlerInstance._fee.call(), 0);
+    assert.equal(await ERC20BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc20ResourceID), 0);
     // Change fee to 0.5 ether
-    await ERC20BasicFeeHandlerInstance.changeFee(fee);
+    await ERC20BasicFeeHandlerInstance.changeFee(destinationDomainID, erc20ResourceID, fee);
     assert.equal(
       web3.utils.fromWei(
-        await ERC20BasicFeeHandlerInstance._fee.call(),
+        await ERC20BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc20ResourceID),
         "ether"
       ),
       "0.5"
@@ -464,12 +464,12 @@ contract("BasicFeeHandler - [collectFee]", async (accounts) => {
 
     const fee = Ethers.utils.parseEther("0.4");
     // current fee is set to 0
-    assert.equal(await ERC721BasicFeeHandlerInstance._fee.call(), 0);
+    assert.equal(await ERC721BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc721ResourceID), 0);
     // Change fee to 0.4 ether
-    await ERC721BasicFeeHandlerInstance.changeFee(fee);
+    await ERC721BasicFeeHandlerInstance.changeFee(destinationDomainID, erc721ResourceID, fee);
     assert.equal(
       web3.utils.fromWei(
-        await ERC721BasicFeeHandlerInstance._fee.call(),
+        await ERC721BasicFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, erc721ResourceID),
         "ether"
       ),
       "0.4"

--- a/test/handlers/fee/basic/distributeFee.js
+++ b/test/handlers/fee/basic/distributeFee.js
@@ -94,9 +94,12 @@ contract("BasicFeeHandler - [distributeFee]", async (accounts) => {
 
   it("should distribute fees", async () => {
     await BridgeInstance.adminChangeFeeHandler(BasicFeeHandlerInstance.address);
-    await BasicFeeHandlerInstance.changeFee(Ethers.utils.parseEther("1"));
+    await BasicFeeHandlerInstance.changeFee(destinationDomainID, resourceID, Ethers.utils.parseEther("1"));
     assert.equal(
-      web3.utils.fromWei(await BasicFeeHandlerInstance._fee.call(), "ether"),
+      web3.utils.fromWei(await BasicFeeHandlerInstance._domainResourceIDToFee(
+        destinationDomainID,
+        resourceID
+        ), "ether"),
       "1"
     );
 
@@ -161,7 +164,7 @@ contract("BasicFeeHandler - [distributeFee]", async (accounts) => {
 
   it("should require admin role to distribute fee", async () => {
     await BridgeInstance.adminChangeFeeHandler(BasicFeeHandlerInstance.address);
-    await BasicFeeHandlerInstance.changeFee(Ethers.utils.parseEther("1"));
+    await BasicFeeHandlerInstance.changeFee(destinationDomainID, resourceID, Ethers.utils.parseEther("1"));
 
     await BridgeInstance.deposit(
       destinationDomainID,
@@ -189,7 +192,7 @@ contract("BasicFeeHandler - [distributeFee]", async (accounts) => {
 
   it("should revert if addrs and amounts arrays have different length", async () => {
     await BridgeInstance.adminChangeFeeHandler(BasicFeeHandlerInstance.address);
-    await BasicFeeHandlerInstance.changeFee(Ethers.utils.parseEther("1"));
+    await BasicFeeHandlerInstance.changeFee(destinationDomainID, resourceID, Ethers.utils.parseEther("1"));
 
     await BridgeInstance.deposit(
       destinationDomainID,

--- a/test/handlers/fee/handlerRouter.js
+++ b/test/handlers/fee/handlerRouter.js
@@ -130,7 +130,7 @@ contract("FeeHandlerRouter", async (accounts) => {
       resourceID,
       BasicFeeHandlerInstance.address
     );
-    await BasicFeeHandlerInstance.changeFee(Ethers.utils.parseEther("0.5"));
+    await BasicFeeHandlerInstance.changeFee(destinationDomainID, resourceID, Ethers.utils.parseEther("0.5"));
 
     const depositData = Helpers.createERCDepositData(100, 20, recipientAddress);
     let res = await FeeHandlerRouterInstance.calculateFee.call(
@@ -163,7 +163,7 @@ contract("FeeHandlerRouter", async (accounts) => {
       resourceID,
       BasicFeeHandlerInstance.address
     );
-    await BasicFeeHandlerInstance.changeFee(Ethers.utils.parseEther("0.5"));
+    await BasicFeeHandlerInstance.changeFee(destinationDomainID, resourceID, Ethers.utils.parseEther("0.5"));
 
     const depositData = Helpers.createERCDepositData(100, 20, recipientAddress);
     await Helpers.expectToRevertWithCustomError(
@@ -173,7 +173,7 @@ contract("FeeHandlerRouter", async (accounts) => {
         destinationDomainID,
         resourceID,
         depositData,
-        feeData, 
+        feeData,
         {
           from: bridgeAddress,
           value: Ethers.utils.parseEther("0.5").toString()
@@ -188,7 +188,7 @@ contract("FeeHandlerRouter", async (accounts) => {
         destinationDomainID,
         resourceID,
         depositData,
-        feeData, 
+        feeData,
         {
           from: bridgeAddress,
           value: Ethers.utils.parseEther("0.5").toString()
@@ -207,7 +207,7 @@ contract("FeeHandlerRouter", async (accounts) => {
       resourceID,
       BasicFeeHandlerInstance.address
     );
-    await BasicFeeHandlerInstance.changeFee(Ethers.utils.parseEther("0.5"));
+    await BasicFeeHandlerInstance.changeFee(destinationDomainID, resourceID, Ethers.utils.parseEther("0.5"));
 
     const depositData = Helpers.createERCDepositData(100, 20, recipientAddress);
     await TruffleAssert.passes(
@@ -217,10 +217,10 @@ contract("FeeHandlerRouter", async (accounts) => {
         destinationDomainID,
         resourceID,
         depositData,
-        feeData, 
+        feeData,
         {
           from: bridgeAddress,
-          value: "0" 
+          value: "0"
         }
       ),
     );

--- a/test/handlers/fee/percentage/admin.js
+++ b/test/handlers/fee/percentage/admin.js
@@ -11,7 +11,8 @@ const ERC20MintableContract = artifacts.require("ERC20PresetMinterPauser");
 
 
 contract("PercentageFeeHandler - [admin]", async (accounts) => {
-  const domainID = 1;
+  const originDomainID = 1;
+  const destinationDomainID = 2;
   const initialRelayers = accounts.slice(0, 3);
   const currentFeeHandlerAdmin = accounts[0];
 
@@ -31,7 +32,7 @@ contract("PercentageFeeHandler - [admin]", async (accounts) => {
   beforeEach(async () => {
     await Promise.all([
       (BridgeInstance = await Helpers.deployBridge(
-        domainID,
+        originDomainID,
         accounts[0]
       )),
       ERC20MintableContract.new("token", "TOK").then(
@@ -49,19 +50,19 @@ contract("PercentageFeeHandler - [admin]", async (accounts) => {
 
     ADMIN_ROLE = await PercentageFeeHandlerInstance.DEFAULT_ADMIN_ROLE();
 
-    resourceID = Helpers.createResourceID(ERC20MintableInstance.address, domainID);
+    resourceID = Helpers.createResourceID(ERC20MintableInstance.address, originDomainID);
   });
 
   it("should set fee property", async () => {
     const fee = 60000;
-    assert.equal(await PercentageFeeHandlerInstance._fee.call(), "0");
-    await PercentageFeeHandlerInstance.changeFee(fee);
-    assert.equal(await PercentageFeeHandlerInstance._fee.call(), fee);
+    assert.equal(await PercentageFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, resourceID), "0");
+    await PercentageFeeHandlerInstance.changeFee(destinationDomainID, resourceID, fee);
+    assert.equal(await PercentageFeeHandlerInstance._domainResourceIDToFee(destinationDomainID, resourceID), fee);
   });
 
   it("should require admin role to change fee property", async () => {
     const fee = 600;
-    await assertOnlyAdmin(PercentageFeeHandlerInstance.changeFee, fee);
+    await assertOnlyAdmin(PercentageFeeHandlerInstance.changeFee, destinationDomainID, resourceID, fee);
   });
 
   it("should set fee bounds", async () => {

--- a/test/handlers/fee/percentage/calculateFee.js
+++ b/test/handlers/fee/percentage/calculateFee.js
@@ -85,7 +85,7 @@ contract("PercentageFeeHandler - [calculateFee]", async (accounts) => {
 
     assert.equal(res[0].toString(), "0");
     // Change fee to 1 BPS ()
-    await PercentageFeeHandlerInstance.changeFee(10000);
+    await PercentageFeeHandlerInstance.changeFee(destinationDomainID, resourceID, 10000);
     await PercentageFeeHandlerInstance.changeFeeBounds(resourceID, 100, 300000);
     res = await FeeHandlerRouterInstance.calculateFee.call(
       relayer,
@@ -114,7 +114,7 @@ contract("PercentageFeeHandler - [calculateFee]", async (accounts) => {
 
     assert.equal(res[0].toString(), "0");
     // Change fee to 1 BPS ()
-    await PercentageFeeHandlerInstance.changeFee(10000);
+    await PercentageFeeHandlerInstance.changeFee(destinationDomainID, resourceID, 10000);
     res = await FeeHandlerRouterInstance.calculateFee.call(
       relayer,
       originDomainID,
@@ -129,7 +129,7 @@ contract("PercentageFeeHandler - [calculateFee]", async (accounts) => {
   it("should return lower bound token amount for fee [lowerBound > 0, upperBound > 0]", async () => {
     const depositData = Helpers.createERCDepositData(10000, 20, recipientAddress);
     await PercentageFeeHandlerInstance.changeFeeBounds(resourceID, 100, 300);
-    await PercentageFeeHandlerInstance.changeFee(10000);
+    await PercentageFeeHandlerInstance.changeFee(destinationDomainID, resourceID, 10000);
 
     res = await FeeHandlerRouterInstance.calculateFee.call(
       relayer,
@@ -145,7 +145,7 @@ contract("PercentageFeeHandler - [calculateFee]", async (accounts) => {
   it("should return lower bound token amount for fee [lowerBound > 0, upperBound = 0]", async () => {
     const depositData = Helpers.createERCDepositData(10000, 20, recipientAddress);
     await PercentageFeeHandlerInstance.changeFeeBounds(resourceID, 100, 0);
-    await PercentageFeeHandlerInstance.changeFee(10000);
+    await PercentageFeeHandlerInstance.changeFee(destinationDomainID, resourceID, 10000);
 
     res = await FeeHandlerRouterInstance.calculateFee.call(
       relayer,
@@ -161,7 +161,7 @@ contract("PercentageFeeHandler - [calculateFee]", async (accounts) => {
   it("should return upper bound token amount for fee [lowerBound = 0, upperBound > 0]", async () => {
     const depositData = Helpers.createERCDepositData(100000000, 20, recipientAddress);
     await PercentageFeeHandlerInstance.changeFeeBounds(resourceID, 0, 300);
-    await PercentageFeeHandlerInstance.changeFee(10000);
+    await PercentageFeeHandlerInstance.changeFee(destinationDomainID, resourceID, 10000);
 
     res = await FeeHandlerRouterInstance.calculateFee.call(
       relayer,
@@ -177,7 +177,7 @@ contract("PercentageFeeHandler - [calculateFee]", async (accounts) => {
   it("should return percentage of token amount for fee [lowerBound = 0, upperBound > 0]", async () => {
     const depositData = Helpers.createERCDepositData(100000, 20, recipientAddress);
     await PercentageFeeHandlerInstance.changeFeeBounds(resourceID, 0, 300);
-    await PercentageFeeHandlerInstance.changeFee(10000);
+    await PercentageFeeHandlerInstance.changeFee(destinationDomainID, resourceID, 10000);
 
     res = await FeeHandlerRouterInstance.calculateFee.call(
       relayer,

--- a/test/handlers/fee/percentage/collectFee.js
+++ b/test/handlers/fee/percentage/collectFee.js
@@ -64,7 +64,7 @@ contract("PercentageFeeHandler - [collectFee]", async (accounts) => {
       originDomainID
     );
 
-    await PercentageFeeHandlerInstance.changeFee(feeBps);
+    await PercentageFeeHandlerInstance.changeFee(destinationDomainID, resourceID, feeBps);
     await PercentageFeeHandlerInstance.changeFeeBounds(resourceID, lowerBound, upperBound);
 
     await Promise.all([

--- a/test/handlers/fee/percentage/distributeFee.js
+++ b/test/handlers/fee/percentage/distributeFee.js
@@ -88,7 +88,7 @@ contract("PercentageFeeHandler - [distributeFee]", async (accounts) => {
         resourceID,
         PercentageFeeHandlerInstance.address
       ),
-      PercentageFeeHandlerInstance.changeFee(feeBps)
+      PercentageFeeHandlerInstance.changeFee(destinationDomainID, resourceID, feeBps)
     ]);
 
     depositData = Helpers.createERCDepositData(


### PR DESCRIPTION
## Description
This introduces a mapping for fees per destination domain. Now we don't have to deploy a new handler for every fee amount, they all can be setup in a single basic/percentage fee handler.

Also removes setting up fees in migrations since now there would be too many moving parts to do it automatically. 
In general we need to rethink about fees and how to approach to migrations.

## Related Issue Or Context
Closes: #205
Closes: #151

## How Has This Been Tested? Testing details.
existing unit and e2e tests  are updated

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
