### PR TITLE
chore: Remove resourceID from FROSTKeygen contract

### DIFF
--- a/contracts/FROSTKeygen.sol
+++ b/contracts/FROSTKeygen.sol
@@ -7,13 +7,13 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract FROSTKeygen is Ownable {
 
-    bool private functionCalled; 
+    bool private keygenStarted; 
     event StartedFROSTKeygen(); 
 
     modifier onlyOnce(){
-        require (!functionCalled, "Function can be called only once");
+        require (!keygenStarted, "FROST keygen can be called only once");
         _; 
-        functionCalled = true; 
+        keygenStarted = true; 
     }
     
     /**

--- a/contracts/FROSTKeygen.sol
+++ b/contracts/FROSTKeygen.sol
@@ -7,13 +7,20 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract FROSTKeygen is Ownable {
 
-    event StartedFROSTKeygen(bytes32 resourceID); 
+    bool private functionCalled; 
+    event StartedFROSTKeygen(); 
+
+    modifier onlyOnce(){
+        require (!functionCalled, "Function can be called only once");
+        _; 
+        functionCalled = true; 
+    }
     
     /**
-        @param resourceID ResourceID for which the keygen is initiated. 
+       @notice Emits {StartedFROSTKeygen} event
      */
-    function startFROSTKeygen(bytes32 resourceID) public onlyOwner { 
-        emit StartedFROSTKeygen(resourceID); 
+    function startFROSTKeygen() public onlyOwner onlyOnce { 
+        emit StartedFROSTKeygen(); 
     }
 
 }

--- a/test/frostKeygen/frostKeygen.js
+++ b/test/frostKeygen/frostKeygen.js
@@ -3,33 +3,37 @@
 
 const TruffleAssert = require("truffle-assertions");
 const FROSTKeygen = artifacts.require("FROSTKeygen")
-const Helpers = require("../helpers");
 
 contract("FROSTKeygen", (accounts) => {
     let FROSTKeygenInstance;
-    let resourceID;
 
     beforeEach(async () => {
         FROSTKeygenInstance = await FROSTKeygen.new(accounts[0]);
-        resourceID = Helpers.createResourceID(
-          "0x",
-          1
-        );
     });
 
-    it("should emit StartedFROSTKeygen event when startKeygen is called by the owner", async () => {
+    it("should emit StartedFROSTKeygen event when startFROSTKeygen is called by the owner", async () => {
 
-      const tx = await FROSTKeygenInstance.startFROSTKeygen(resourceID, {from: accounts[0]})
+      const tx = await FROSTKeygenInstance.startFROSTKeygen({from: accounts[0]})
 
-      TruffleAssert.eventEmitted(tx, "StartedFROSTKeygen", (event) => {
-        return event.resourceID === resourceID
-      }, "StartedFROSTKeygen event should be emitted with correct resourceID");
+      TruffleAssert.eventEmitted(tx, "StartedFROSTKeygen");
 
     });
 
-    it("should revert when it's not called by the owner", async () => {
+    it("should revert when startFROSTKeygen is not called by the owner", async () => {
+
       await TruffleAssert.reverts(
-        FROSTKeygenInstance.startFROSTKeygen(resourceID, {from: accounts[1]}),
+        FROSTKeygenInstance.startFROSTKeygen({from: accounts[1]}),
       )
+
     });
+
+    it("should revert when startFROSTKeygen is called more than once", async() => {
+
+      const tx = await FROSTKeygenInstance.startFROSTKeygen({from: accounts[0]})
+
+      TruffleAssert.eventEmitted(tx, "StartedFROSTKeygen");
+
+      await TruffleAssert.reverts(
+        FROSTKeygenInstance.startFROSTKeygen({from: accounts[0]}))
+      })
 })


### PR DESCRIPTION
Removed resourceID from FROSTKeygen contract and made it callable only once. 

closes #229 