### PR TITLE
feat: extend fee calculation formula

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Forked Mainnet Tests
         run: |
           fuser -k 8545/tcp
-          make start-forkedMainnet
+          make start-forkedMainnet FORKED_TESTS_PROVIDER=${{ secrets.FORKED_TESTS_PROVIDER }}
           npx truffle test testUnderForked/*
 
   coverage:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ start-ganache:
 
 start-forkedMainnet:
 	@echo " > \033[32mStarting forked environment... \033[0m "
-	ganache-cli -f https://eth-mainnet.g.alchemy.com/v2/34NZ4AoqM8OSolHSol6jh5xZSPq1rcL- & sleep 3
+	ganache-cli -f $(FORKED_TESTS_PROVIDER) & sleep 3
 
 start-geth:
 	@echo " > \033[32mStarting geth... \033[0m "

--- a/contracts/handlers/FeeHandlerRouter.sol
+++ b/contracts/handlers/FeeHandlerRouter.sol
@@ -91,7 +91,7 @@ contract FeeHandlerRouter is IFeeHandler, AccessControl {
         feeHandler.collectFee{value: msg.value}(sender, fromDomainID, destinationDomainID, resourceID, depositData, feeData);
     }
 
-     /**
+    /**
         @notice Initiates calculating fee with corresponding fee handler contract using IFeeHandler interface.
         @param sender Sender of the deposit.
         @param fromDomainID ID of the source chain.

--- a/contracts/handlers/fee/V2/DynamicERC20FeeHandlerEVMV2.sol
+++ b/contracts/handlers/fee/V2/DynamicERC20FeeHandlerEVMV2.sol
@@ -30,10 +30,9 @@ contract DynamicERC20FeeHandlerEVMV2 is DynamicFeeHandlerV2 {
         Fee memory destFeeConfig = destinationFee[destinationDomainID];
 
         uint256 txCost = destFeeConfig.gasPrice * _gasUsed * desintationCoinPrice / 1e18;
-        if(destFeeConfig.feeType == 0x01) {
+        if(destFeeConfig.feeType == ProtocolFeeType.Fixed) {
             txCost += destFeeConfig.amount;
-        }
-        if(destFeeConfig.feeType == 0x02) {
+        } else if (destFeeConfig.feeType == ProtocolFeeType.Percentage) {
             txCost += txCost * destFeeConfig.amount / 1e4; // 100 for percent and 100 to avoid precision loss;
         }
 

--- a/contracts/handlers/fee/V2/DynamicFeeHandlerV2.sol
+++ b/contracts/handlers/fee/V2/DynamicFeeHandlerV2.sol
@@ -24,7 +24,14 @@ abstract contract DynamicFeeHandlerV2 is IFeeHandler, AccessControl {
     uint32 public _gasUsed;
 
     mapping(uint8 => address) public destinationNativeCoinWrap;
-    mapping(uint8 => uint256) public destinationGasPrice;
+    mapping(uint8 => Fee) public destinationFee;
+    mapping(uint8 => mapping(bytes32 => Fee)) public _domainResourceIDToFee;
+
+    struct Fee {
+        uint256 gasPrice;
+        bytes1 feeType;
+        uint248 amount;
+    }
 
     event FeeOracleAddressSet(TwapOracle feeOracleAddress);
     event FeePropertySet(uint32 gasUsed);
@@ -95,9 +102,16 @@ abstract contract DynamicFeeHandlerV2 is IFeeHandler, AccessControl {
         @notice Sets the gas price for destination chain.
         @param destinationDomainID ID of destination chain.
         @param gasPrice Gas price of destination chain.
+        @param feeType Type of fee that can be set (fixed/percentage).
+                "0x01" => fixed fee
+                "0x02" => percentage fee
+        @param amount Fee amount that should be additional charged on top of
+        execution cost (fixed native token amount/percentage of execution cost).
      */
-    function setGasPrice(uint8 destinationDomainID, uint256 gasPrice) external onlyAdmin {
-        destinationGasPrice[destinationDomainID] = gasPrice;
+    function setGasPrice(uint8 destinationDomainID, uint256 gasPrice, bytes1 feeType, uint248 amount) external onlyAdmin {
+        destinationFee[destinationDomainID].gasPrice = gasPrice;
+        destinationFee[destinationDomainID].feeType = feeType;
+        destinationFee[destinationDomainID].amount = amount;
         emit GasPriceSet(destinationDomainID, gasPrice);
     }
 
@@ -140,7 +154,7 @@ abstract contract DynamicFeeHandlerV2 is IFeeHandler, AccessControl {
         emit FeeCollected(sender, fromDomainID, destinationDomainID, resourceID, fee, address(0));
     }
 
-     /**
+    /**
         @notice Calculates fee for deposit.
         @param sender Sender of the deposit.
         @param fromDomainID ID of the source chain.

--- a/contracts/handlers/fee/V2/DynamicFeeHandlerV2.sol
+++ b/contracts/handlers/fee/V2/DynamicFeeHandlerV2.sol
@@ -20,16 +20,22 @@ abstract contract DynamicFeeHandlerV2 is IFeeHandler, AccessControl {
     address public immutable _feeHandlerRouterAddress;
 
     TwapOracle public twapOracle;
+    ProtocolFeeType public protocolFeeType;
 
     uint32 public _gasUsed;
 
     mapping(uint8 => address) public destinationNativeCoinWrap;
     mapping(uint8 => Fee) public destinationFee;
-    mapping(uint8 => mapping(bytes32 => Fee)) public _domainResourceIDToFee;
+
+    enum ProtocolFeeType {
+        None,
+        Fixed,
+        Percentage
+    }
 
     struct Fee {
         uint256 gasPrice;
-        bytes1 feeType;
+        ProtocolFeeType feeType;
         uint248 amount;
     }
 
@@ -103,12 +109,13 @@ abstract contract DynamicFeeHandlerV2 is IFeeHandler, AccessControl {
         @param destinationDomainID ID of destination chain.
         @param gasPrice Gas price of destination chain.
         @param feeType Type of fee that can be set (fixed/percentage).
-                "0x01" => fixed fee
-                "0x02" => percentage fee
+                "0" => execution cost
+                "1" => execution cost + protocol fee (fixed fee)
+                "2" => execution cost + protocol fee (percentage fee)
         @param amount Fee amount that should be additional charged on top of
         execution cost (fixed native token amount/percentage of execution cost).
      */
-    function setGasPrice(uint8 destinationDomainID, uint256 gasPrice, bytes1 feeType, uint248 amount) external onlyAdmin {
+    function setGasPrice(uint8 destinationDomainID, uint256 gasPrice, ProtocolFeeType feeType, uint248 amount) external onlyAdmin {
         destinationFee[destinationDomainID].gasPrice = gasPrice;
         destinationFee[destinationDomainID].feeType = feeType;
         destinationFee[destinationDomainID].amount = amount;

--- a/contracts/handlers/fee/V2/DynamicGenericFeeHandlerEVMV2.sol
+++ b/contracts/handlers/fee/V2/DynamicGenericFeeHandlerEVMV2.sol
@@ -32,10 +32,9 @@ contract DynamicGenericFeeHandlerEVMV2 is DynamicFeeHandlerV2 {
         Fee memory destFeeConfig = destinationFee[destinationDomainID];
 
         uint256 txCost = destFeeConfig.gasPrice * maxFee * desintationCoinPrice / 1e18;
-        if(destFeeConfig.feeType == 0x01) {
+        if(destFeeConfig.feeType == ProtocolFeeType.Fixed) {
             txCost += destFeeConfig.amount;
-        }
-        if(destFeeConfig.feeType == 0x02) {
+        } else if (destFeeConfig.feeType == ProtocolFeeType.Percentage) {
             txCost += txCost * destFeeConfig.amount / 1e4; // 100 for percent and 100 to avoid precision loss;
         }
 

--- a/contracts/handlers/fee/V2/DynamicGenericFeeHandlerEVMV2.sol
+++ b/contracts/handlers/fee/V2/DynamicGenericFeeHandlerEVMV2.sol
@@ -18,7 +18,7 @@ contract DynamicGenericFeeHandlerEVMV2 is DynamicFeeHandlerV2 {
     constructor(address bridgeAddress, address feeHandlerRouterAddress) DynamicFeeHandlerV2(bridgeAddress, feeHandlerRouterAddress) {
     }
 
-     /**
+    /**
         @notice Calculates fee for transaction cost.
         @param destinationDomainID ID of chain deposit will be bridged to.
         @param depositData Additional data to be passed to specified handler.
@@ -29,7 +29,16 @@ contract DynamicGenericFeeHandlerEVMV2 is DynamicFeeHandlerV2 {
         uint256 maxFee = uint256(bytes32(depositData[:32]));
         uint256 desintationCoinPrice = twapOracle.getPrice(destinationNativeCoinWrap[destinationDomainID]);
         if (desintationCoinPrice == 0) revert IncorrectPrice();
-        uint256 txCost = destinationGasPrice[destinationDomainID] * maxFee * desintationCoinPrice / 1e18;
+        Fee memory destFeeConfig = destinationFee[destinationDomainID];
+
+        uint256 txCost = destFeeConfig.gasPrice * maxFee * desintationCoinPrice / 1e18;
+        if(destFeeConfig.feeType == 0x01) {
+            txCost += destFeeConfig.amount;
+        }
+        if(destFeeConfig.feeType == 0x02) {
+            txCost += txCost * destFeeConfig.amount / 1e4; // 100 for percent and 100 to avoid precision loss;
+        }
+
         return (txCost, address(0));
     }
 }

--- a/testUnderForked/collectFeeERC20EVM.js
+++ b/testUnderForked/collectFeeERC20EVM.js
@@ -31,6 +31,8 @@ contract("DynamicERC20FeeHandlerEVMV2 - [collectFee]", async (accounts) => {
   const destinationDomainID = 3;
   const gasUsed = 100000;
   const gasPrice = 200000000000;
+  const fixedFeeType = "0x01";
+  const fixedProtocolFee = Ethers.utils.parseEther("0.001");
   const sender = accounts[0];
   const UNISWAP_V3_FACTORY_ADDRESS = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
   const WETH_ADDRESS = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
@@ -109,7 +111,12 @@ contract("DynamicERC20FeeHandlerEVMV2 - [collectFee]", async (accounts) => {
       DynamicFeeHandlerInstance.address
     );
     await DynamicFeeHandlerInstance.setFeeOracle(TwapOracleInstance.address);
-    await DynamicFeeHandlerInstance.setGasPrice(destinationDomainID, gasPrice); // Polygon gas price is 200 Gwei
+    await DynamicFeeHandlerInstance.setGasPrice(
+      destinationDomainID,
+      gasPrice,  // Polygon gas price is 200 Gwei
+      fixedFeeType,
+      fixedProtocolFee
+    );
     await DynamicFeeHandlerInstance.setWrapTokenAddress(destinationDomainID, MATIC_ADDRESS);
     await DynamicFeeHandlerInstance.setFeeProperties(gasUsed);
 
@@ -225,7 +232,7 @@ contract("DynamicERC20FeeHandlerEVMV2 - [collectFee]", async (accounts) => {
 
   it("deposit should revert if the destination coin's price is 0", async () => {
     const fee = Ethers.utils.parseEther("1.0");
-    await TwapOracleInstance.setPrice(MATIC_ADDRESS, 0); 
+    await TwapOracleInstance.setPrice(MATIC_ADDRESS, 0);
 
     await Helpers.expectToRevertWithCustomError(
       BridgeInstance.deposit(

--- a/testUnderForked/collectFeeERC20EVM.js
+++ b/testUnderForked/collectFeeERC20EVM.js
@@ -31,7 +31,11 @@ contract("DynamicERC20FeeHandlerEVMV2 - [collectFee]", async (accounts) => {
   const destinationDomainID = 3;
   const gasUsed = 100000;
   const gasPrice = 200000000000;
-  const fixedFeeType = "0x01";
+  const ProtocolFeeType = {
+    None: "0",
+    Fixed: "1",
+    Percentage: "2"
+  }
   const fixedProtocolFee = Ethers.utils.parseEther("0.001");
   const sender = accounts[0];
   const UNISWAP_V3_FACTORY_ADDRESS = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
@@ -114,7 +118,7 @@ contract("DynamicERC20FeeHandlerEVMV2 - [collectFee]", async (accounts) => {
     await DynamicFeeHandlerInstance.setGasPrice(
       destinationDomainID,
       gasPrice,  // Polygon gas price is 200 Gwei
-      fixedFeeType,
+      ProtocolFeeType.Fixed,
       fixedProtocolFee
     );
     await DynamicFeeHandlerInstance.setWrapTokenAddress(destinationDomainID, MATIC_ADDRESS);

--- a/testUnderForked/collectFeeGenericEVM.js
+++ b/testUnderForked/collectFeeGenericEVM.js
@@ -29,6 +29,8 @@ contract("DynamicGenericFeeHandlerEVMV2 - [collectFee]", async (accounts) => {
   const originDomainID = 1;
   const destinationDomainID = 3;
   const gasPrice = 200000000000;
+  const fixedFeeType = "0x01";
+  const fixedProtocolFee = Ethers.utils.parseEther("0.001");
   const sender = accounts[0];
   const UNISWAP_V3_FACTORY_ADDRESS = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
   const WETH_ADDRESS = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
@@ -113,7 +115,12 @@ contract("DynamicGenericFeeHandlerEVMV2 - [collectFee]", async (accounts) => {
       DynamicFeeHandlerInstance.address
     );
     await DynamicFeeHandlerInstance.setFeeOracle(TwapOracleInstance.address);
-    await DynamicFeeHandlerInstance.setGasPrice(destinationDomainID, gasPrice); // Polygon gas price is 200 Gwei
+    await DynamicFeeHandlerInstance.setGasPrice(
+      destinationDomainID,
+      gasPrice,  // Polygon gas price is 200 Gwei
+      fixedFeeType,
+      fixedProtocolFee
+    );
     await DynamicFeeHandlerInstance.setWrapTokenAddress(destinationDomainID, MATIC_ADDRESS);
 
     await Promise.all([
@@ -226,7 +233,7 @@ contract("DynamicGenericFeeHandlerEVMV2 - [collectFee]", async (accounts) => {
 
   it("deposit should revert if the destination coin's price is 0", async () => {
     const fee = Ethers.utils.parseEther("1.0");
-    await TwapOracleInstance.setPrice(MATIC_ADDRESS, 0); 
+    await TwapOracleInstance.setPrice(MATIC_ADDRESS, 0);
 
     await Helpers.expectToRevertWithCustomError(
       BridgeInstance.deposit(

--- a/testUnderForked/collectFeeGenericEVM.js
+++ b/testUnderForked/collectFeeGenericEVM.js
@@ -29,7 +29,11 @@ contract("DynamicGenericFeeHandlerEVMV2 - [collectFee]", async (accounts) => {
   const originDomainID = 1;
   const destinationDomainID = 3;
   const gasPrice = 200000000000;
-  const fixedFeeType = "0x01";
+  const ProtocolFeeType = {
+    None: "0",
+    Fixed: "1",
+    Percentage: "2"
+  }
   const fixedProtocolFee = Ethers.utils.parseEther("0.001");
   const sender = accounts[0];
   const UNISWAP_V3_FACTORY_ADDRESS = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
@@ -118,7 +122,7 @@ contract("DynamicGenericFeeHandlerEVMV2 - [collectFee]", async (accounts) => {
     await DynamicFeeHandlerInstance.setGasPrice(
       destinationDomainID,
       gasPrice,  // Polygon gas price is 200 Gwei
-      fixedFeeType,
+      ProtocolFeeType.Fixed,
       fixedProtocolFee
     );
     await DynamicFeeHandlerInstance.setWrapTokenAddress(destinationDomainID, MATIC_ADDRESS);


### PR DESCRIPTION
## Description
Extends the fee calculation formula with the option to charge on top of execution fee a protocol fee.
Protocol fee can be a fixed amount of native token or a percentage of the execution cost.

## Related Issue Or Context
Closes: #242 

## How Has This Been Tested? Testing details.
unit test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
