### PR TITLE
chore: update what gets pushed to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "build/contracts/TwapOracle.json",
     "build/contracts/TwapFeeHandler.json",
     "build/contracts/FeeHandlerRouter.json",
+    "build/contracts/NativeTokenAdapter.json",
+    "build/contracts/NativeTokenHandler.json",
     "contracts/interfaces"
   ],
   "directories": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "build/contracts/ERC721Handler.json",
     "build/contracts/ERC1155Handler.json",
     "build/contracts/GmpHandler.json",
-    "build/contract/FeeHandlerRouter.json",
     "build/contracts/BasicFeeHandler.json",
     "build/contracts/PercentageERC20FeeHandler.json",
-    "build/contracts/DynamicGenericFeeHandler.json",
-    "build/contracts/DynamicERC20FeeHandler.json",
+    "build/contracts/PercentageERC20FeeHandler.json",
+    "build/contracts/TwapOracle.json",
+    "build/contracts/TwapFeeHandler.json",
+    "build/contracts/FeeHandlerRouter.json",
     "contracts/interfaces"
   ],
   "directories": {


### PR DESCRIPTION
## Description
* Dynamic generic fee handlers don't exist anymore (v1 dynamic fee handlers) - they are replaced with Twap fee handlers.
* Fixes typo for fee handler router because of which it didn't get published to npm.